### PR TITLE
Set up CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,36 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19.x
+        cache: true
+
+    - name: Lint
+      run: make lint
+
+    - name: Build
+      run: make build
+
+    - name: Test
+      run: make cover
+      env:
+        TEST_FLAGS: '-v -race'
+
+    # TODO: Enable after public
+    # - name: Upload coverage
+    #   uses: codecov/codecov-action@v3


### PR DESCRIPTION
Set up a GitHub Workflow to run tests,
and dependabot to update dependencies.

Tests run with data-race detection enabled.

Coverage uploading is disabled until the project is public.
