### PR TITLE
godoc, gosrc: Drop stub pointers

### DIFF
--- a/internal/godoc/assemble.go
+++ b/internal/godoc/assemble.go
@@ -24,21 +24,11 @@ type Linker interface {
 // Assembler assembles a [Package] from a [go/doc.Package].
 type Assembler struct {
 	Linker Linker
-
-	// Reference to doc.NewFromFiles.
-	//
-	// May be overridden during tests.
-	docNewFromFiles func(*token.FileSet, []*ast.File, string, ...any) (*doc.Package, error)
 }
 
 // Assemble runs the assembler on the given doc.Package.
 func (a *Assembler) Assemble(bpkg *gosrc.Package) (*Package, error) {
-	docNewFromFiles := doc.NewFromFiles
-	if a.docNewFromFiles != nil {
-		docNewFromFiles = a.docNewFromFiles
-	}
-
-	dpkg, err := docNewFromFiles(bpkg.Fset, bpkg.Syntax, bpkg.ImportPath)
+	dpkg, err := doc.NewFromFiles(bpkg.Fset, bpkg.Syntax, bpkg.ImportPath)
 	if err != nil {
 		return nil, fmt.Errorf("assemble documentation: %w", err)
 	}

--- a/internal/gosrc/finder.go
+++ b/internal/gosrc/finder.go
@@ -56,11 +56,6 @@ type Finder struct {
 	//
 	// Use nil to disable debug logging.
 	DebugLog *log.Logger
-
-	// Reference to packages.Load.
-	//
-	// May be overridden during tests.
-	loadGoPackages func(*packages.Config, ...string) ([]*packages.Package, error)
 }
 
 const _finderLoadMode = packages.NeedName | packages.NeedCompiledGoFiles | packages.NeedImports
@@ -85,12 +80,7 @@ func (f *Finder) FindPackages(patterns ...string) ([]*PackageRef, error) {
 		cfg.Logf = f.DebugLog.Printf
 	}
 
-	loadGoPackages := packages.Load
-	if f.loadGoPackages != nil {
-		loadGoPackages = f.loadGoPackages
-	}
-
-	pkgs, err := loadGoPackages(&cfg, patterns...)
+	pkgs, err := packages.Load(&cfg, patterns...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The Assembler, Parser, and Finder types
have fields holding references to top-level functions.
These were intended to be stubbed out from tests.
So far, we haven't needed to do this,
so drop them for now.
