### PR TITLE
html: Renderer should know about -internal

### DIFF
--- a/internal/html/tmpl/subpackages.html
+++ b/internal/html/tmpl/subpackages.html
@@ -2,7 +2,7 @@
 
 <table>
   <tbody>
-    {{ range .Subpackages -}}
+    {{ range (filterSubpackages .Subpackages) -}}
       <tr>
         <td><a href="{{ .RelativePath }}">{{ .RelativePath }}</a></td>
         <td>

--- a/main.go
+++ b/main.go
@@ -88,16 +88,15 @@ func (cmd *mainCmd) run(opts *params) error {
 
 	g := Generator{
 		Log:    cmd.log,
-		Finder: &finder,
 		Parser: new(gosrc.Parser),
 		Assembler: &godoc.Assembler{
 			Linker: &linker,
 		},
 		Renderer: &html.Renderer{
 			Embedded: opts.Embedded,
+			Internal: opts.Internal,
 		},
 		OutDir:    opts.OutputDir,
-		Internal:  opts.Internal,
 		DocLinker: &linker,
 	}
 


### PR DESCRIPTION
Generator currently inspects the -internal flag to decide
which subpackages to feed to the Renderer
for a package or directory's subpackage listing.

It makes better sense for this information to be made
available to the Renderer and have it decide
whether it wants to render internal packages or not.

This change moves the Internal bool to the Renderer.
This also helped DRY up the tests for subpackage listings
and breadcrumbs.
