### PR TITLE
Generate a top-level index

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -73,7 +73,9 @@ func (r *Generator) Generate(pkgRefs []*gosrc.PackageRef) error {
 		return err
 	}
 
-	_, err := r.renderTrees(nil, buildTrees(pkgRefs))
+	_, err := r.renderTree(nil, packageTree{
+		Children: buildTrees(pkgRefs),
+	})
 	return err
 }
 
@@ -96,7 +98,9 @@ func (r *Generator) renderTree(crumbs []html.Breadcrumb, t packageTree) ([]*rend
 	} else {
 		crumbText = t.Path
 	}
-	crumbs = append(crumbs, html.Breadcrumb{Text: crumbText, Path: t.Path})
+	if len(crumbText) > 0 {
+		crumbs = append(crumbs, html.Breadcrumb{Text: crumbText, Path: t.Path})
+	}
 
 	if t.Value == nil {
 		return r.renderPackageIndex(crumbs, t)

--- a/generate_test.go
+++ b/generate_test.go
@@ -58,6 +58,11 @@ func TestGenerator_hierarchy(t *testing.T) {
 						{RelativePath: "foo/bar", Synopsis: "package bar does things."},
 					},
 				},
+				"": {
+					Subpackages: []html.Subpackage{
+						{RelativePath: "example.com/foo/bar", Synopsis: "package bar does things."},
+					},
+				},
 			},
 		},
 		{
@@ -90,6 +95,13 @@ func TestGenerator_hierarchy(t *testing.T) {
 				},
 			},
 			wantDirs: map[string]*renderInfo{
+				"": {
+					Subpackages: []html.Subpackage{
+						{RelativePath: "a/b/c", Synopsis: "package c"},
+						{RelativePath: "a/b/e", Synopsis: "package e"},
+						{RelativePath: "a/d", Synopsis: "package d"},
+					},
+				},
 				"a": {
 					Breadcrumbs: []html.Breadcrumb{
 						{Text: "a", Path: "a"},

--- a/internal/html/tmpl/layout.html
+++ b/internal/html/tmpl/layout.html
@@ -8,16 +8,18 @@
     {{ template "Head" $ -}}
   </head>
   <body>
-    <nav>
-      {{ range $idx, $crumb := .Breadcrumbs -}}
-        {{ if gt $idx 0 }}/{{ end -}}
-        {{ with (relativePath .Path) -}}
-          <a href="{{ . }}">{{ $crumb.Text }}</a>
-        {{- else -}}
-          {{ $crumb.Text -}}
+    {{ with .Breadcrumbs -}}
+      <nav>
+        {{ range $idx, $crumb := . -}}
+          {{ if gt $idx 0 }}/{{ end -}}
+          {{ with (relativePath .Path) -}}
+            <a href="{{ . }}">{{ $crumb.Text }}</a>
+          {{- else -}}
+            {{ $crumb.Text -}}
+          {{ end -}}
         {{ end -}}
-      {{ end -}}
-    </nav>
+      </nav>
+    {{- end -}}
     <main>{{ template "Body" $ -}}</main>
     <script src="{{ static "js/permalink.js" }}"></script>
   </body>


### PR DESCRIPTION
Instead of generating indexes only at the first level directories,
generate an index at the top level for subpackages/directories.
