### PR TITLE
Add -basename flag

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -23,6 +23,7 @@ type params struct {
 	Patterns  []string
 	Internal  bool
 	Embedded  bool
+	Basename  string
 
 	PackageDocTemplates []pathTemplate
 }
@@ -76,6 +77,8 @@ func (cmd *cliParser) newFlagSet() (*params, *flag.FlagSet) {
 	flag.Var(&p.Debug, "debug", "print debugging output to stderr or FILE,\n"+
 		"if specified in the form -debug=FILE.")
 	flag.StringVar(&p.Tags, "tags", "", "list of comma-separated build tags.")
+	flag.StringVar(&p.Basename, "basename", "", "base name of generated files.\n"+
+		"Defaults to index.html.")
 	return &p, flag
 }
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -46,6 +46,15 @@ func TestCLIParser(t *testing.T) {
 				Patterns:  []string{"std", "example.com/..."},
 			},
 		},
+		{
+			desc: "basename",
+			give: []string{"-basename", "_index.html", "./..."},
+			want: params{
+				OutputDir: "_site",
+				Basename:  "_index.html",
+				Patterns:  []string{"./..."},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/generate.go
+++ b/generate.go
@@ -67,6 +67,11 @@ type Generator struct {
 	// It will be created it if it doesn't exist.
 	OutDir string
 
+	// Basename of generated files.
+	//
+	// Defaults to index.html.
+	Basename string
+
 	once sync.Once
 }
 
@@ -74,6 +79,9 @@ func (r *Generator) init() {
 	r.once.Do(func() {
 		if r.DebugLog == nil {
 			r.DebugLog = log.New(io.Discard, "", 0)
+		}
+		if r.Basename == "" {
+			r.Basename = "index.html"
 		}
 	})
 }
@@ -138,7 +146,7 @@ func (r *Generator) renderPackageIndex(crumbs []html.Breadcrumb, t packageTree) 
 		return nil, err
 	}
 
-	f, err := os.Create(filepath.Join(dir, "index.html"))
+	f, err := os.Create(filepath.Join(dir, r.Basename))
 	if err != nil {
 		return nil, err
 	}
@@ -184,8 +192,7 @@ func (r *Generator) renderPackage(crumbs []html.Breadcrumb, t packageTree) (*ren
 		return nil, err
 	}
 
-	// TODO: For Hugo, this should be _index.html.
-	f, err := os.Create(filepath.Join(dir, "index.html"))
+	f, err := os.Create(filepath.Join(dir, r.Basename))
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -105,6 +105,7 @@ func (cmd *mainCmd) run(opts *params) error {
 			Internal: opts.Internal,
 		},
 		OutDir:    opts.OutputDir,
+		Basename:  opts.Basename,
 		DocLinker: &linker,
 	}
 


### PR DESCRIPTION
Adds a -basename flag that allows changing the
base name of generated files -- e.g. index.html => _index.html.

Resolves #13
