### PR TITLE
flag: Don't parse templates while parsing flags

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"strings"
-	"text/template"
 
 	"go.abhg.dev/doc2go/internal/flagvalue"
 )
@@ -109,8 +108,7 @@ func (cmd *cliParser) Parse(args []string) (*params, error) {
 
 type pathTemplate struct {
 	Path     string
-	Template *template.Template
-	rawTmpl  string
+	Template string
 }
 
 var _ flag.Getter = (*pathTemplate)(nil)
@@ -118,7 +116,7 @@ var _ flag.Getter = (*pathTemplate)(nil)
 func (pt *pathTemplate) Get() any { return pt }
 
 func (pt *pathTemplate) String() string {
-	return fmt.Sprintf("%s=%s", pt.Path, pt.rawTmpl)
+	return fmt.Sprintf("%s=%s", pt.Path, pt.Template)
 }
 
 func (pt *pathTemplate) Set(s string) error {
@@ -128,13 +126,6 @@ func (pt *pathTemplate) Set(s string) error {
 	}
 
 	pt.Path = s[:idx]
-	pt.rawTmpl = s[idx+1:]
-
-	var err error
-	pt.Template, err = template.New(pt.Path).Parse(pt.rawTmpl)
-	if err != nil {
-		return fmt.Errorf("bad template: %w", err)
-	}
-
+	pt.Template = s[idx+1:]
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"text/template"
 
 	"go.abhg.dev/doc2go/internal/godoc"
 	"go.abhg.dev/doc2go/internal/gosrc"
@@ -88,7 +89,11 @@ func (cmd *mainCmd) run(opts *params) error {
 
 	var linker docLinker
 	for _, lt := range opts.PackageDocTemplates {
-		linker.Template(lt.Path, lt.Template)
+		t, err := template.New(lt.Path).Parse(lt.Template)
+		if err != nil {
+			return fmt.Errorf("bad package documentation template %q: %w", lt.String(), err)
+		}
+		linker.Template(lt.Path, t)
 	}
 	for _, ref := range pkgRefs {
 		linker.LocalPackage(ref.ImportPath)

--- a/main_test.go
+++ b/main_test.go
@@ -47,6 +47,18 @@ func TestMainCmd_unknownFlag(t *testing.T) {
 	assert.NotZero(t, exitCode, "unknown flag should have non-zero status code")
 }
 
+func TestMainCmd_badTemplate(t *testing.T) {
+	t.Parallel()
+
+	var buff bytes.Buffer
+	exitCode := (&mainCmd{
+		Stdout: iotest.Writer(t),
+		Stderr: &buff,
+	}).Run([]string{"-pkg-doc", "foo=bar{{.baz", "./..."})
+	assert.NotZero(t, exitCode)
+	assert.Contains(t, buff.String(), "bad package documentation template")
+}
+
 func TestMainCmd_generate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
If we parse templates during flag parsing,
we limit the functions that can be available in the template
significantly.

Store them as strings during flag parsing,
and parse the text/template in main.
