### PR TITLE
html: Skip Directories section if all internal

### DIFF
--- a/internal/html/tmpl/directory.html
+++ b/internal/html/tmpl/directory.html
@@ -3,5 +3,7 @@
 {{ end -}}
 
 {{ define "Body" -}}
-  {{ template "subpackages.html" . -}}
+  {{ with (filterSubpackages .Subpackages) -}}
+    {{ template "subpackages.html" . -}}
+  {{ end -}}
 {{ end -}}

--- a/internal/html/tmpl/package.html
+++ b/internal/html/tmpl/package.html
@@ -86,7 +86,7 @@
   {{ end -}}
 {{ end -}}
 
-{{ if .Subpackages -}}
+{{ with (filterSubpackages .Subpackages) -}}
   {{ template "subpackages.html" . -}}
 {{ end -}}
 {{ end -}}

--- a/internal/html/tmpl/subpackages.html
+++ b/internal/html/tmpl/subpackages.html
@@ -2,7 +2,7 @@
 
 <table>
   <tbody>
-    {{ range (filterSubpackages .Subpackages) -}}
+    {{ range . -}}
       <tr>
         <td><a href="{{ .RelativePath }}">{{ .RelativePath }}</a></td>
         <td>


### PR DESCRIPTION
If all subpackages are internal,
and we are not rendering internal listings,
don't generate the "Directories" section.
