### PR TITLE
Add -frontmatter flag

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -25,9 +25,11 @@ type params struct {
 	Basename  string
 	OutputDir string
 
-	Embed    bool
-	Internal bool
-	PkgDocs  []pathTemplate
+	Embed           bool
+	Internal        bool
+	PkgDocs         []pathTemplate
+	Frontmatter     string
+	FrontmatterFile string
 
 	Patterns []string
 }
@@ -75,6 +77,8 @@ func (cmd *cliParser) newFlagSet() (*params, *flag.FlagSet) {
 	// HTML output:
 	flag.BoolVar(&p.Internal, "internal", false, "")
 	flag.BoolVar(&p.Embed, "embed", false, "")
+	flag.StringVar(&p.Frontmatter, "frontmatter", "", "")
+	flag.StringVar(&p.FrontmatterFile, "frontmatter-file", "", "")
 	flag.Var(flagvalue.ListOf(&p.PkgDocs), "pkg-doc", "")
 
 	// Go build system:
@@ -96,6 +100,12 @@ func (cmd *cliParser) Parse(args []string) (*params, error) {
 	if p.version {
 		fmt.Fprintln(cmd.Stdout, "doc2go", _version)
 		return nil, errHelp
+	}
+
+	if len(p.Frontmatter) > 0 && len(p.FrontmatterFile) > 0 {
+		fmt.Fprintln(cmd.Stderr, "Only one of -frontmatter and -frontmatter-file may be specified.")
+		cmd.printShortUsage()
+		return nil, errInvalidArguments
 	}
 
 	p.Patterns = flag.Args()

--- a/flags.txt
+++ b/flags.txt
@@ -11,16 +11,40 @@
 	include internal packages in package listings.
 	We always generate documentation for internal packages, but without
 	this flag set, we will not include them in package lists.
+  -frontmatter TEMPLATE
+	generate front matter in HTML files via TEMPLATE.
+	TEMPLATE executes with the following object:
+		struct {
+			// Path to the package or directory from module root.
+			// Path is empty for the root index page.
+			Path string
+			// Last component of Path, if any.
+			Basename string
+			// Number of packages or directories inside Path.
+			NumChildren int
+			// Fields in Package are set only if Path is a package.
+			Package struct {
+				// Name of the package.
+				Name string
+				// One sentence description of the package.
+				Synopsis string
+			}
+		}
+	By default, generates files do not have front matter.
+  -frontmatter-file FILE
+	read front matter template from FILE.
+	See -frontmatter for more details.
   -pkg-doc PATH=TEMPLATE
-	use TEMPLATE to generate documentation links for PATH and its children.
+	generate documentation links for PATH and its children via TEMPLATE.
 	  -pkg-doc example.com=https://godoc.example.com/{{.ImportPath}}
-	The template is a text/template that gets the following object:
+	TEMPLATE executes with the following object:
 		struct {
 			// Import path of the target package.
 			ImportPath string
 		}
 	Pass this in multiple times to specify different patterns for different
-	import path scopes.
+	scopes.
+	By default, packages not under PATTERNs will use https://pkg.go.dev.
   -tags TAG,...
 	list of comma-separated build tags.
   -debug[=FILE]

--- a/flags_test.go
+++ b/flags_test.go
@@ -87,6 +87,30 @@ func TestCLIParser(t *testing.T) {
 				OutputDir: "_site",
 			},
 		},
+		{
+			desc: "frontmatter",
+			give: []string{
+				"-frontmatter", "{{.Path}}",
+				"./...",
+			},
+			want: params{
+				Frontmatter: "{{.Path}}",
+				Patterns:    []string{"./..."},
+				OutputDir:   "_site",
+			},
+		},
+		{
+			desc: "frontmatter-file",
+			give: []string{
+				"-frontmatter-file", "frontmatter.tmpl",
+				"./...",
+			},
+			want: params{
+				FrontmatterFile: "frontmatter.tmpl",
+				Patterns:        []string{"./..."},
+				OutputDir:       "_site",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -124,6 +148,15 @@ func TestCLIParser_Errors(t *testing.T) {
 			desc: "missing '=' in template",
 			give: []string{"-pkg-doc", "foo"},
 			want: "expected form 'path=template'",
+		},
+		{
+			desc: "frontmatter and frontmatter-file",
+			give: []string{
+				"-frontmatter={{.Path}}",
+				"-frontmatter-file=file.txt",
+				"./...",
+			},
+			want: "Only one of -frontmatter and -frontmatter-file",
 		},
 	}
 

--- a/generate.go
+++ b/generate.go
@@ -154,6 +154,7 @@ func (r *Generator) renderPackageIndex(crumbs []html.Breadcrumb, t packageTree) 
 
 	idx := html.PackageIndex{
 		Path:        t.Path,
+		NumChildren: len(t.Children),
 		Subpackages: htmlSubpackages(t.Path, subpkgs),
 		Breadcrumbs: crumbs,
 	}
@@ -200,6 +201,7 @@ func (r *Generator) renderPackage(crumbs []html.Breadcrumb, t packageTree) (*ren
 
 	info := html.PackageInfo{
 		Package:     dpkg,
+		NumChildren: len(t.Children),
 		Breadcrumbs: crumbs,
 		Subpackages: htmlSubpackages(dpkg.ImportPath, subpkgs),
 		DocPrinter: &html.CommentDocPrinter{

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -147,4 +148,101 @@ func testMainCmdGenerate(t *testing.T, exporter packagestest.Exporter) {
 			}
 		})
 	}
+}
+
+func TestMainCmd_frontmatter(t *testing.T) {
+	t.Parallel()
+
+	const template = "---\ntitle: {{.Path}}\n---"
+
+	frontmatterFile := filepath.Join(t.TempDir(), "frontmatter.txt")
+	require.NoError(t,
+		os.WriteFile(frontmatterFile, []byte(template), 0o644))
+
+	mod := packagestest.Module{
+		Name: "foo/bar",
+		Files: map[string]any{
+			"bar.go": "package bar",
+		},
+	}
+	assertFileHasPrefix := func(t *testing.T, path, want string) {
+		bs, err := os.ReadFile(path)
+		require.NoError(t, err)
+
+		got := string(bs)
+		if !strings.HasPrefix(got, want) {
+			t.Errorf("File %v must start with %q\nGot:\n%v", path, want, got)
+		}
+	}
+
+	tests := []struct {
+		desc    string
+		give    []string
+		wantFoo string
+		wantBar string
+	}{
+		{
+			desc: "frontmatter flag",
+			give: []string{
+				"-frontmatter", template,
+			},
+			wantFoo: "---\ntitle: foo\n---\n\n",
+			wantBar: "---\ntitle: foo/bar\n---\n\n",
+		},
+		{
+			desc: "frontmatter file",
+			give: []string{
+				"-frontmatter-file", frontmatterFile,
+			},
+			wantFoo: "---\ntitle: foo\n---\n\n",
+			wantBar: "---\ntitle: foo/bar\n---\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			exported := packagestest.Export(t,
+				packagestest.Modules, []packagestest.Module{mod})
+
+			outDir := t.TempDir()
+			args := append(tt.give, "-out", outDir, "-debug", "./...")
+
+			exitCode := (&mainCmd{
+				Stdout:         iotest.Writer(t),
+				Stderr:         iotest.Writer(t),
+				packagesConfig: exported.Config,
+			}).Run(args)
+			require.Zero(t, exitCode, "expected success")
+
+			assertFileHasPrefix(t,
+				filepath.Join(outDir, "foo/index.html"), tt.wantFoo)
+			assertFileHasPrefix(t,
+				filepath.Join(outDir, "foo/bar/index.html"), tt.wantBar)
+		})
+	}
+}
+
+func TestMainCmd_frontmatter_errors(t *testing.T) {
+	t.Run("bad syntax", func(t *testing.T) {
+		var buff bytes.Buffer
+		exitCode := (&mainCmd{
+			Stdout: iotest.Writer(t),
+			Stderr: &buff,
+		}).Run([]string{"-frontmatter", "{{", "./..."})
+		require.NotZero(t, exitCode, "expected success")
+		assert.Contains(t, buff.String(), "bad frontmatter template")
+	})
+
+	t.Run("file does not exist", func(t *testing.T) {
+		var buff bytes.Buffer
+		exitCode := (&mainCmd{
+			Stdout: iotest.Writer(t),
+			Stderr: &buff,
+		}).Run([]string{"-frontmatter-file", "does-not-exist.txt", "./..."})
+		require.NotZero(t, exitCode, "expected success")
+		assert.Contains(t, buff.String(), "no such file or directory")
+	})
 }


### PR DESCRIPTION
Adds a -frontmatter and -frontmatter-file flag
that lets users specify a text/template or a file containing one.

If specified, this template will be run for each generated HTML file,
and the result will be prepended to the top of each HTML file,
separated from the rest of the content with an empty line.

Although text/template is a bit rough,
this provides enough flexibility to use doc2go with a variety
of different Hugo and Jekyll templates.

Resolves #14
