### PR TITLE
Single -frontmatter flag

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -25,11 +25,10 @@ type params struct {
 	Basename  string
 	OutputDir string
 
-	Embed           bool
-	Internal        bool
-	PkgDocs         []pathTemplate
-	Frontmatter     string
-	FrontmatterFile string
+	Embed       bool
+	Internal    bool
+	PkgDocs     []pathTemplate
+	Frontmatter string
 
 	Patterns []string
 }
@@ -78,7 +77,6 @@ func (cmd *cliParser) newFlagSet() (*params, *flag.FlagSet) {
 	flag.BoolVar(&p.Internal, "internal", false, "")
 	flag.BoolVar(&p.Embed, "embed", false, "")
 	flag.StringVar(&p.Frontmatter, "frontmatter", "", "")
-	flag.StringVar(&p.FrontmatterFile, "frontmatter-file", "", "")
 	flag.Var(flagvalue.ListOf(&p.PkgDocs), "pkg-doc", "")
 
 	// Go build system:
@@ -100,12 +98,6 @@ func (cmd *cliParser) Parse(args []string) (*params, error) {
 	if p.version {
 		fmt.Fprintln(cmd.Stdout, "doc2go", _version)
 		return nil, errHelp
-	}
-
-	if len(p.Frontmatter) > 0 && len(p.FrontmatterFile) > 0 {
-		fmt.Fprintln(cmd.Stderr, "Only one of -frontmatter and -frontmatter-file may be specified.")
-		cmd.printShortUsage()
-		return nil, errInvalidArguments
 	}
 
 	p.Patterns = flag.Args()

--- a/flags.txt
+++ b/flags.txt
@@ -11,9 +11,9 @@
 	include internal packages in package listings.
 	We always generate documentation for internal packages, but without
 	this flag set, we will not include them in package lists.
-  -frontmatter TEMPLATE
-	generate front matter in HTML files via TEMPLATE.
-	TEMPLATE executes with the following object:
+  -frontmatter FILE
+	generate front matter in HTML files via template in FILE.
+	The template inside FILE runs with the following object:
 		struct {
 			// Path to the package or directory from module root.
 			// Path is empty for the root index page.
@@ -31,13 +31,10 @@
 			}
 		}
 	By default, generates files do not have front matter.
-  -frontmatter-file FILE
-	read front matter template from FILE.
-	See -frontmatter for more details.
   -pkg-doc PATH=TEMPLATE
 	generate documentation links for PATH and its children via TEMPLATE.
 	  -pkg-doc example.com=https://godoc.example.com/{{.ImportPath}}
-	TEMPLATE executes with the following object:
+	TEMPLATE runs with the following object:
 		struct {
 			// Import path of the target package.
 			ImportPath string

--- a/flags_test.go
+++ b/flags_test.go
@@ -90,25 +90,13 @@ func TestCLIParser(t *testing.T) {
 		{
 			desc: "frontmatter",
 			give: []string{
-				"-frontmatter", "{{.Path}}",
+				"-frontmatter", "fm.txt",
 				"./...",
 			},
 			want: params{
-				Frontmatter: "{{.Path}}",
+				Frontmatter: "fm.txt",
 				Patterns:    []string{"./..."},
 				OutputDir:   "_site",
-			},
-		},
-		{
-			desc: "frontmatter-file",
-			give: []string{
-				"-frontmatter-file", "frontmatter.tmpl",
-				"./...",
-			},
-			want: params{
-				FrontmatterFile: "frontmatter.tmpl",
-				Patterns:        []string{"./..."},
-				OutputDir:       "_site",
 			},
 		},
 	}
@@ -148,15 +136,6 @@ func TestCLIParser_Errors(t *testing.T) {
 			desc: "missing '=' in template",
 			give: []string{"-pkg-doc", "foo"},
 			want: "expected form 'path=template'",
-		},
-		{
-			desc: "frontmatter and frontmatter-file",
-			give: []string{
-				"-frontmatter={{.Path}}",
-				"-frontmatter-file=file.txt",
-				"./...",
-			},
-			want: "Only one of -frontmatter and -frontmatter-file",
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -100,18 +100,15 @@ func (cmd *mainCmd) run(opts *params) error {
 	}
 
 	var frontmatter *template.Template
-	if path := opts.FrontmatterFile; len(path) > 0 {
+	if path := opts.Frontmatter; len(path) > 0 {
 		bs, err := os.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("frontmatter file %q: %w", path, err)
+			return fmt.Errorf("-frontmatter: %w", err)
 		}
-		opts.Frontmatter = string(bs)
-	}
-	if fm := opts.Frontmatter; len(fm) > 0 {
-		var err error
-		frontmatter, err = template.New("frontmatter").Parse(fm)
+
+		frontmatter, err = template.New(path).Parse(string(bs))
 		if err != nil {
-			return fmt.Errorf("bad frontmatter template: %w\n%s", err, fm)
+			return fmt.Errorf("bad frontmatter template: %w\n%s", err, bs)
 		}
 	}
 


### PR DESCRIPTION
Instead of a frontmatter-file and frontmatter flag,
use just a single frontmatter flag that's always a file.
Frontmatter templates will typically be specified in files.
