### PR TITLE
main: Drop '-o' alias for '-out'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ tidycheck:
 		false; \
 	fi
 
-$(DOC2GO): $(GO_SRC_FILES)
+$(DOC2GO): $(GO_SRC_FILES) flags.txt $(wildcard ./internal/html/tmpl/*)
 	go install go.abhg.dev/doc2go
 
 $(STATICCHECK): tools/go.mod

--- a/flags.go
+++ b/flags.go
@@ -70,7 +70,6 @@ func (cmd *cliParser) newFlagSet() (*params, *flag.FlagSet) {
 
 	// Filesystem:
 	flag.StringVar(&p.OutputDir, "out", "_site", "")
-	flag.StringVar(&p.OutputDir, "o", "_site", "")
 	flag.StringVar(&p.Basename, "basename", "", "")
 
 	// HTML output:

--- a/flags.txt
+++ b/flags.txt
@@ -1,47 +1,52 @@
   -basename NAME
 	base name of generated files. Defaults to index.html.
-  -o, -out DIR
+  -out DIR
 	write files to DIR. Defaults to _site.
   -embed
 	generate partial HTML pages fit for embedding.
-	Instead of generating a standalone HTML website, generate partial HTML
-	pages that can be incorporated into a website using a static site
-	generator.
+	Instead of generating a standalone HTML website,
+	generate partial HTML pages that can be embedded
+	into another website with a static site generator.
   -internal
 	include internal packages in package listings.
-	We always generate documentation for internal packages, but without
-	this flag set, we will not include them in package lists.
+	We always generate documentation for internal packages,
+	but without this flag they will not be listed.
   -frontmatter FILE
 	generate front matter in HTML files via template in FILE.
 	The template inside FILE runs with the following object:
 		struct {
-			// Path to the package or directory from module root.
-			// Path is empty for the root index page.
+			// Path to the package or directory
+			// relative to the module root.
+			// This is empty for the root index page.
 			Path string
-			// Last component of Path, if any.
+			// Last component of Path.
+			// This is empty for the root index page.
 			Basename string
-			// Number of packages or directories inside Path.
+			// Number of packages or directories
+			// directly inside Path.
 			NumChildren int
-			// Fields in Package are set only if Path is a package.
 			Package struct {
 				// Name of the package.
+				// Empty for directories.
 				Name string
-				// One sentence description of the package.
+				// First sentence of the package
+				// documentation, if any.
 				Synopsis string
 			}
 		}
 	By default, generates files do not have front matter.
   -pkg-doc PATH=TEMPLATE
-	generate documentation links for PATH and its children via TEMPLATE.
-	  -pkg-doc example.com=https://godoc.example.com/{{.ImportPath}}
+	generate links for PATH and its children via TEMPLATE.
+	  -pkg-doc example.com=https://go.example.com/{{.ImportPath}}
 	TEMPLATE runs with the following object:
 		struct {
 			// Import path of the target package.
 			ImportPath string
 		}
-	Pass this in multiple times to specify different patterns for different
-	scopes.
-	By default, packages not under PATTERNs will use https://pkg.go.dev.
+	Pass this multiple times to set different templates
+	for different package scopes.
+	Packages that don't match these, and are not part of PATTERNs
+	will use https://pkg.go.dev.
   -tags TAG,...
 	list of comma-separated build tags.
   -debug[=FILE]


### PR DESCRIPTION
'-out' is short enough. We don't need to lose '-o' to that.
