### PR TITLE
parser: Ignore test files for now

### DIFF
--- a/internal/gosrc/parser.go
+++ b/internal/gosrc/parser.go
@@ -52,16 +52,20 @@ func (*Parser) ParsePackage(ref *PackageRef) (*Package, error) {
 		sort.Strings(topLevel)
 	}
 
-	testSyntax, err := parseFiles(fset, ref.TestFiles, nil)
-	if err != nil {
-		return nil, err
-	}
+	// TODO:
+	// Parse test files to extract example tests.
+	// https://github.com/abhinav/doc2go/issues/15
+	//
+	// testSyntax, err := parseFiles(fset, ref.TestFiles, nil)
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	return &Package{
-		Name:          ref.Name,
-		ImportPath:    ref.ImportPath,
-		Syntax:        syntax,
-		TestSyntax:    testSyntax,
+		Name:       ref.Name,
+		ImportPath: ref.ImportPath,
+		Syntax:     syntax,
+		// TestSyntax:    testSyntax,
 		Fset:          fset,
 		TopLevelDecls: topLevel,
 	}, nil

--- a/internal/gosrc/parser_test.go
+++ b/internal/gosrc/parser_test.go
@@ -27,9 +27,10 @@ func TestParsePackage_simple(t *testing.T) {
 	if files := got.Syntax; assert.Len(t, files, 1) {
 		assert.Equal(t, srcFile, got.Fset.File(files[0].Pos()).Name())
 	}
-	if files := got.TestSyntax; assert.Len(t, files, 1) {
-		assert.Equal(t, testFile, got.Fset.File(files[0].Pos()).Name())
-	}
+	// https://github.com/abhinav/doc2go/issues/15
+	// if files := got.TestSyntax; assert.Len(t, files, 1) {
+	// 	assert.Equal(t, testFile, got.Fset.File(files[0].Pos()).Name())
+	// }
 	assert.Equal(t, []string{
 		"Constant",
 		"Function",


### PR DESCRIPTION
Ignore test files because we're not yet extracting examples from them.

Refs #15
