### PR TITLE
finder: Use GoFiles, not CompiledGoFiles

### DIFF
--- a/.changes/unreleased/Fixed-20230110-092244.yaml
+++ b/.changes/unreleased/Fixed-20230110-092244.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Resolve intermittent "No non-test Go files" messages for uncompiled packages.
+time: 2023-01-10T09:22:44.837641-08:00


### PR DESCRIPTION
Finder should use the GoFiles attribute to access the source files,
not CompiledGoFiles, which looks at the processed files.

This is a leftover of coding this against go/packages' NeedsSyntax,
which is supposed to be in the order of CompiledGoFiles.

Resolves #54
