### PR TITLE
Add -home flag

### DIFF
--- a/.changes/unreleased/Added-20230112-095400.yaml
+++ b/.changes/unreleased/Added-20230112-095400.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add '-home' flag to change the landing page of the generated website.
+time: 2023-01-12T09:54:00.948665-08:00

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -30,12 +30,16 @@ standalone: $(STANDALONE_REF)
 embedded: $(EMBEDDED_REF)
 
 $(STANDALONE_REF): $(DOC2GO)
-	cd .. && $(DOC2GO) -internal -out docs/content/en/example ./...
+	cd .. && $(DOC2GO) \
+		-internal \
+		-home go.abhg.dev/doc2go \
+		-out docs/content/en/example ./...
 
 $(EMBEDDED_REF): $(DOC2GO) frontmatter.tmpl
 	cd .. && $(DOC2GO) \
 		-basename _index.html -embed -internal \
 		-frontmatter docs/frontmatter.tmpl \
+		-home go.abhg.dev/doc2go \
 		-out docs/content/en/api ./...
 
 content/en/docs/usage/usage.txt: $(DOC2GO)

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -41,10 +41,10 @@ sidebar_menu_compact = false
 
 [[params.menu.examples]]
   name = "Embedded"
-  url = "api/go.abhg.dev/doc2go"
+  url = "api/"
 [[params.menu.examples]]
   name = "Standalone"
-  url = "example/go.abhg.dev/doc2go"
+  url = "example/"
 
 [params.links]
   [[params.links.developer]]

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -25,9 +25,9 @@ It's a simpler, self-hosted alternative to services like
 https://pkg.go.dev/ and https://godocs.io/.
 
 You can use doc2go to generate standalone HTML websites
-([example](example/go.abhg.dev/doc2go)),
+([example](example/)),
 or embed your documentation inside another static website
-([example](api/go.abhg.dev/doc2go)).
+([example](api/)).
 
 <a class="btn btn-dark" href="{{< relref "docs/publish/github-pages" >}}">
   <i class="fa-brands fa-github"></i> Publish to GitHub Pages

--- a/docs/content/en/docs/_index.md
+++ b/docs/content/en/docs/_index.md
@@ -55,14 +55,14 @@ check out the following links:
 
 {{< cardpane >}}
 
-{{% card header="[**Standalone**](../example/go.abhg.dev/doc2go/)" %}}
+{{% card header="[**Standalone**](../example/)" %}}
 A documentation website generated from doc2go's own source code
-is available [here](../example/go.abhg.dev/doc2go/).
+is available [here](../example/).
 {{% /card %}}
 
-{{% card header="[**Embedded**](../api/go.abhg.dev/doc2go/)" %}}
+{{% card header="[**Embedded**](../api/)" %}}
 A copy of the same documentation embedded into this website
-is available [here](../api/go.abhg.dev/doc2go/).
+is available [here](../api/).
 {{% /card %}}
 
 {{< /cardpane >}}

--- a/docs/content/en/docs/publish/github-pages.md
+++ b/docs/content/en/docs/publish/github-pages.md
@@ -139,3 +139,29 @@ on:
 ```
 
 Use `master` above if the name of your main branch is `master`.
+
+## Changing the home page
+
+The generated website includes the import path of the package in the URL.
+This can result in longer URLs than desirable.
+For example, for `github.com/$user/$proj`,
+the documentation will be at:
+
+    https://$user.github.io/$proj/github.com/$user/$proj
+
+If you'd like to change this, change the "Generate API reference"
+step above to:
+
+```yaml
+          - name: Generate API reference
+            run: doc2go -home github.com/${{ github.repository }} ./...
+```
+
+Now, the documentation for that package will be at:
+
+    https://$user.github.io/$proj/
+
+{{% alert title="Note" %}}
+Use the import path for your module instead of the above
+if you're using a vanity import path.
+{{% /alert %}}

--- a/docs/content/en/docs/usage/_index.md
+++ b/docs/content/en/docs/usage/_index.md
@@ -76,6 +76,30 @@ doc2go -out public ./...
 
 The directory will be created if it doesn't exist.
 
+### Home page
+
+By default, the landing page of the generated website
+is an index of the topmost Go packages in the generation scope.
+
+So if you're generating documentation for the package `example.com/foo`,
+in the generated website:
+
+- `/` is a page that links to `example.com/foo`
+- `/example.com/foo` holds documentation for  `example.com/foo`
+- `/example.com/foo/bar` holds documentation for  `example.com/foo/bar`
+
+doc2go supports a `-home` flag that allows you to change this.
+Given the above, if you run:
+
+```bash
+doc2go -home example.com/foo ./...
+```
+
+Then, in the generated website:
+
+- `/` holds documentation for  `example.com/foo`
+- `/bar` holds documentation for  `example.com/foo/bar`
+
 #### Base name
 
 All generated pages use the name "index.html".

--- a/docs/content/en/docs/usage/usage.txt
+++ b/docs/content/en/docs/usage/usage.txt
@@ -12,6 +12,9 @@ OPTIONS
 	base name of generated files. Defaults to index.html.
   -out DIR
 	write files to DIR. Defaults to _site.
+  -home PATH
+	import path for the home page of the documentation.
+	Packages that aren't descendants of this path will be omitted.
   -embed
 	generate partial HTML pages fit for embedding.
   -internal

--- a/docs/frontmatter.tmpl
+++ b/docs/frontmatter.tmpl
@@ -8,16 +8,11 @@ title: "
 "
 no_list: true
 type: docs
-{{ $base := "go.abhg.dev/doc2go" -}}
-{{ if ge (len .Path) (len $base) -}}
 github_repo: "https://github.com/abhinav/doc2go"
 github_subdir: ""
 path_base_for_github_subdir:
-  from: "content/en/api/{{ $base }}(/(.*?))?/_index.html"
+  from: "content/en/api(/(.*?))?/_index.html"
   to: "$2"
-{{ else -}}
-github_repo: ""
-{{ end -}}
 {{ with .Package.Synopsis -}}
   description: {{ printf "%q" . }}
 {{ else -}}

--- a/flags.go
+++ b/flags.go
@@ -25,6 +25,7 @@ type params struct {
 
 	Basename  string
 	OutputDir string
+	Home      string
 
 	Embed       bool
 	Internal    bool
@@ -52,6 +53,7 @@ func (cmd *cliParser) newFlagSet() (*params, *flag.FlagSet) {
 	// Filesystem:
 	flag.StringVar(&p.OutputDir, "out", "_site", "")
 	flag.StringVar(&p.Basename, "basename", "", "")
+	flag.StringVar(&p.Home, "home", "", "")
 
 	// HTML output:
 	flag.BoolVar(&p.Internal, "internal", false, "")

--- a/flags_test.go
+++ b/flags_test.go
@@ -99,6 +99,15 @@ func TestCLIParser(t *testing.T) {
 				OutputDir:   "_site",
 			},
 		},
+		{
+			desc: "home",
+			give: []string{"-home", "go.abhg.dev/doc2go", "./..."},
+			want: params{
+				Home:      "go.abhg.dev/doc2go",
+				Patterns:  []string{"./..."},
+				OutputDir: "_site",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/help.go
+++ b/help.go
@@ -49,6 +49,9 @@ OPTIONS
 	base name of generated files. Defaults to index.html.
   -out DIR
 	write files to DIR. Defaults to _site.
+  -home PATH
+	import path for the home page of the documentation.
+	Packages that aren't descendants of this path will be omitted.
   -embed
 	generate partial HTML pages fit for embedding.
   -internal

--- a/integration_test.go
+++ b/integration_test.go
@@ -22,10 +22,16 @@ func TestIntegration_noBrokenLinks(t *testing.T) {
 	tests := []struct {
 		desc    string
 		pattern string
+		args    []string
 	}{
 		{
 			desc:    "self",
 			pattern: "./...",
+		},
+		{
+			desc:    "self/home",
+			pattern: "./...",
+			args:    []string{"-home", "go.abhg.dev/doc2go"},
 		},
 		{
 			desc:    "testify",
@@ -47,10 +53,12 @@ func TestIntegration_noBrokenLinks(t *testing.T) {
 			t.Parallel()
 
 			outDir := t.TempDir()
+			args := append(tt.args, "-out="+outDir, "-debug", "-internal", tt.pattern)
+
 			exitCode := (&mainCmd{
 				Stdout: iotest.Writer(t),
 				Stderr: iotest.Writer(t),
-			}).Run([]string{"-out=" + outDir, "-debug", "-internal", tt.pattern})
+			}).Run(args)
 			require.Zero(t, exitCode)
 
 			srv := httptest.NewServer(http.FileServer(http.FS(os.DirFS(outDir))))

--- a/internal/html/render.go
+++ b/internal/html/render.go
@@ -48,6 +48,9 @@ var (
 
 // Renderer renders components into HTML.
 type Renderer struct {
+	// Path to the home page of the generated site.
+	Home string
+
 	// Whether we're in embedded mode.
 	// In this mode, output will only contain the documentation output
 	// and will not generate complete, stylized HTML pages.
@@ -176,6 +179,7 @@ func (r *Renderer) RenderPackage(w io.Writer, info *PackageInfo) error {
 		return err
 	}
 	render := render{
+		Home:       r.Home,
 		Path:       info.ImportPath,
 		DocPrinter: info.DocPrinter,
 		Internal:   r.Internal,
@@ -230,6 +234,7 @@ func (r *Renderer) RenderPackageIndex(w io.Writer, pidx *PackageIndex) error {
 		NumChildren: pidx.NumChildren,
 	})
 	render := render{
+		Home:     r.Home,
 		Path:     pidx.Path,
 		Internal: r.Internal,
 	}
@@ -239,6 +244,7 @@ func (r *Renderer) RenderPackageIndex(w io.Writer, pidx *PackageIndex) error {
 }
 
 type render struct {
+	Home string
 	Path string
 
 	Internal bool
@@ -262,7 +268,7 @@ func (r *render) relativePath(p string) string {
 }
 
 func (r *render) static(p string) string {
-	return r.relativePath(path.Join(_staticDir, p))
+	return r.relativePath(path.Join(r.Home, _staticDir, p))
 }
 
 func (r *render) doc(lvl int, doc *comment.Doc) template.HTML {

--- a/internal/pathx/descend.go
+++ b/internal/pathx/descend.go
@@ -1,0 +1,13 @@
+package pathx
+
+import "strings"
+
+// Descends reports whether b is equal to, or a descendant of a.
+func Descends(a, b string) bool {
+	a = strings.TrimSuffix(a, "/")
+	if !strings.HasPrefix(b, a) {
+		return false
+	}
+	b = b[len(a):]
+	return b == "" || b[0] == '/'
+}

--- a/internal/pathx/descend_test.go
+++ b/internal/pathx/descend_test.go
@@ -1,0 +1,32 @@
+package pathx
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDescends(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"foo", "bar", false},
+		{"foo", "foobar", false},
+		{"foo", "foo/bar", true},
+		{"foo/", "foo/bar", true},
+		{"foo/", "foobar", false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("Descends(%q,%q)", tt.a, tt.b), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, Descends(tt.a, tt.b))
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -133,6 +133,7 @@ func (cmd *mainCmd) run(opts *params) error {
 			Linker: &linker,
 		},
 		Renderer: &html.Renderer{
+			Home:        opts.Home,
 			Embedded:    opts.Embed,
 			Internal:    opts.Internal,
 			FrontMatter: frontmatter,


### PR DESCRIPTION
Adds a -home flag which allows changing the home page
for the generated website.

With this, if you add `-home $importPath`,
then the landing page of the generated website
is the documentation for `$importPath`.

Resolves #58
