### PR TITLE
standalone: Add a small "generated by" footer

### DIFF
--- a/.changes/unreleased/Added-20230118-204543.yaml
+++ b/.changes/unreleased/Added-20230118-204543.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: Include a small footer on standalone pages indicating the page was generated
+  by doc2go.
+time: 2023-01-18T20:45:43.67171986-08:00

--- a/internal/html/static/css/main.css
+++ b/internal/html/static/css/main.css
@@ -54,3 +54,5 @@ pre {
   padding: 0.75em;
   font-size: 0.9em;
 }
+
+#generated-by-footer { font-size: x-small; }

--- a/internal/html/tmpl/layout.html
+++ b/internal/html/tmpl/layout.html
@@ -4,6 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="generator" content="doc2go">
     <link href="{{ static "css/main.css" }}" rel="stylesheet" />
     {{ template "Head" $ -}}
   </head>
@@ -21,6 +22,12 @@
       </nav>
     {{- end -}}
     <main>{{ template "Body" $ -}}</main>
+    <hr>
+    <footer>
+      <small id="generated-by-footer">
+        Generated with <a href="https://abhinav.github.io/doc2go/">doc2go</a>
+      </small>
+    </footer>
     <script src="{{ static "js/permalink.js" }}"></script>
   </body>
 </html>


### PR DESCRIPTION
Adds a *very small* footer
at the bottom of each page in standalone mode
that indicates that it was generated by doc2go.
