### PR TITLE
Add configuration support

### DIFF
--- a/.changes/unreleased/Added-20230119-193054.yaml
+++ b/.changes/unreleased/Added-20230119-193054.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: Add support for reading configuration from a file. Defaults to reading from
+  doc2go.rc; can be changed with the '-config' flag.
+time: 2023-01-19T19:30:54.907351983-08:00

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -30,18 +30,10 @@ standalone: $(STANDALONE_REF)
 embedded: $(EMBEDDED_REF)
 
 $(STANDALONE_REF): $(DOC2GO)
-	cd .. && $(DOC2GO) \
-		-internal \
-		-home go.abhg.dev/doc2go \
-		-out docs/content/en/example ./...
+	cd .. && $(DOC2GO) -config docs/standalone.rc ./...
 
 $(EMBEDDED_REF): $(DOC2GO) frontmatter.tmpl
-	cd .. && $(DOC2GO) \
-		-basename _index.html -embed -internal \
-		-frontmatter docs/frontmatter.tmpl \
-		-highlight classes:tango \
-		-home go.abhg.dev/doc2go \
-		-out docs/content/en/api ./...
+	cd .. && $(DOC2GO) -config docs/embed.rc ./...
 
 assets/scss/_chroma.scss: $(DOC2GO)
 	$(DOC2GO) -highlight=tango -highlight-print-css > $@

--- a/docs/content/en/docs/usage/config.md
+++ b/docs/content/en/docs/usage/config.md
@@ -1,0 +1,72 @@
+---
+title: Configuration
+weight: 1
+description: >-
+  Configure doc2go with configuration files
+  instead of command line flags.
+---
+
+Configuration for doc2go is read from a file named **doc2go.rc**
+expected in the directory where doc2go is running.
+
+## Configuration format
+
+The configuration file is a list of newline-separated options.
+Each line is in one of the following forms:
+
+    key
+    key value
+
+Where `key` is the name of an option and `value` is the value for it.
+The value may contain spaces and punctuation without escaping or quoting.
+If the option is a boolean switch, then `value` is not present.
+
+For example:
+
+```
+home go.abhg.dev/doc2go
+embed
+theme inline:tango
+```
+
+Lines that start with `#` are treated as comments.
+
+```
+# Use godocs.io for example.com/foo.
+pkg-doc example.com/foo=https://godocs.io/{{.ImportPath}}
+```
+
+### Options
+
+doc2go accepts nearly all [command line flags]({{< relref "/docs/usage#cli-reference" >}})
+as configuration parameters.
+
+Flags which accept values are specified alongside them:
+
+    home go.abhg.dev/doc2go
+
+Whereas boolean flags are specified alone on their own lines:
+
+    embed
+    internal
+
+See  [CLI Reference]({{< relref "/docs/usage#cli-reference" >}})
+for a list of flags.
+
+## Using a different file
+
+Configuration may be stored in a file other than doc2go.rc.
+Specify the path to this file while invoking doc2go
+to read configuration from it.
+
+```bash
+doc2go -config other.rc ./...
+```
+
+You can use this flag to have different configurations for
+your embedded versus standalone sites, for example.
+
+```bash
+doc2go -config embedded.rc ./...
+doc2go -config standalone.rc ./...
+```

--- a/docs/content/en/docs/usage/frontmatter.md
+++ b/docs/content/en/docs/usage/frontmatter.md
@@ -1,7 +1,8 @@
 ---
-title: Adding front matter
+title: Front matter
 description: >-
   Add front matter to generated pages.
+weight: 2
 ---
 
 ## Background

--- a/docs/content/en/docs/usage/highlight.md
+++ b/docs/content/en/docs/usage/highlight.md
@@ -2,6 +2,7 @@
 title: Syntax Highlighting
 description: >-
   Customize doc2go's syntax highlighting of code blocks.
+weight: 3
 ---
 
 doc2go highlights code inside API reference declarations

--- a/docs/content/en/docs/usage/links.md
+++ b/docs/content/en/docs/usage/links.md
@@ -1,5 +1,5 @@
 ---
-title: Configuring external links
+title: External links
 description: >-
   Change how doc2go generates links to external repositories.
 ---

--- a/docs/embed.rc
+++ b/docs/embed.rc
@@ -1,0 +1,11 @@
+embed
+internal
+home go.abhg.dev/doc2go
+
+highlight classes:tango
+
+# Hugo-needs
+basename _index.html
+frontmatter docs/frontmatter.tmpl
+
+out docs/content/en/api

--- a/docs/standalone.rc
+++ b/docs/standalone.rc
@@ -1,0 +1,3 @@
+internal
+home go.abhg.dev/doc2go
+out docs/content/en/example

--- a/flags.go
+++ b/flags.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/alecthomas/chroma/v2/styles"
+	ff "github.com/peterbourgon/ff/v3"
 	"go.abhg.dev/doc2go/internal/flagvalue"
 )
 
@@ -23,8 +24,9 @@ type params struct {
 	version bool
 	help    Help
 
-	Tags  string
-	Debug flagvalue.FileSwitch
+	Tags   string
+	Debug  flagvalue.FileSwitch
+	Config string
 
 	Basename  string
 	OutputDir string
@@ -51,7 +53,7 @@ type cliParser struct {
 	Stderr io.Writer
 }
 
-func (cmd *cliParser) newFlagSet() (*params, *flag.FlagSet) {
+func (cmd *cliParser) newFlagSet(cfg *configFileParser) (*params, *flag.FlagSet) {
 	flag := flag.NewFlagSet("doc2go", flag.ContinueOnError)
 	flag.SetOutput(cmd.Stderr)
 	flag.Usage = func() {
@@ -75,25 +77,34 @@ func (cmd *cliParser) newFlagSet() (*params, *flag.FlagSet) {
 	flag.Var(&p.Highlight, "highlight", "")
 	flag.BoolVar(&p.HighlightPrintCSS, "highlight-print-css", false, "")
 	flag.BoolVar(&p.HighlightListThemes, "highlight-list-themes", false, "")
+	cfg.Reject("highlight-print-css", "highlight-list-themes")
 
 	// Go build system:
 	flag.StringVar(&p.Tags, "tags", "", "")
 
 	// Program-level:
 	flag.Var(&p.Debug, "debug", "")
+	flag.StringVar(&p.Config, "config", "doc2go.rc", "")
 	flag.BoolVar(&p.version, "version", false, "")
 	flag.Var(&p.help, "help", "")
 	flag.Var(&p.help, "h", "")
+	cfg.Reject("version", "help", "h")
 
 	return &p, flag
 }
 
 func (cmd *cliParser) Parse(args []string) (*params, error) {
-	p, flag := cmd.newFlagSet()
-	if err := flag.Parse(args); err != nil {
+	var cfgParser configFileParser
+	p, fset := cmd.newFlagSet(&cfgParser)
+	err := ff.Parse(fset, args,
+		ff.WithAllowMissingConfigFile(true),
+		ff.WithConfigFileVia(&p.Config),
+		ff.WithConfigFileParser(cfgParser.Parse),
+	)
+	if err != nil {
 		return nil, err
 	}
-	args = flag.Args()
+	args = fset.Args()
 
 	if p.version {
 		fmt.Fprintln(cmd.Stdout, "doc2go", _version)
@@ -115,6 +126,18 @@ func (cmd *cliParser) Parse(args []string) (*params, error) {
 		if err := p.help.Write(cmd.Stderr); err != nil {
 			fmt.Fprintln(cmd.Stderr, err)
 		}
+
+		// For configuration,
+		// also print a list of available parameters.
+		if p.help == "config" {
+			fmt.Fprintln(cmd.Stderr, "\nThe following flags may be speciifed via configuration:")
+			fset.VisitAll(func(f *flag.Flag) {
+				if cfgParser.Allowed(f.Name) {
+					fmt.Fprintf(cmd.Stderr, "  %v\n", f.Name)
+				}
+			})
+		}
+
 		return nil, errHelp
 	}
 
@@ -209,4 +232,39 @@ func (pt *pathTemplate) Set(s string) error {
 	pt.Path = s[:idx]
 	pt.Template = s[idx+1:]
 	return nil
+}
+
+type configFileParser struct {
+	disallowed map[string]struct{}
+}
+
+func (f *configFileParser) Reject(names ...string) {
+	if f == nil {
+		return
+	}
+	if f.disallowed == nil {
+		f.disallowed = make(map[string]struct{})
+	}
+
+	for _, name := range names {
+		f.disallowed[name] = struct{}{}
+	}
+}
+
+func (f *configFileParser) Allowed(name string) bool {
+	_, disallow := f.disallowed[name]
+	return !disallow
+}
+
+func (f *configFileParser) Parse(r io.Reader, set func(string, string) error) error {
+	if f == nil {
+		return nil
+	}
+
+	return ff.PlainParser(r, func(name, value string) error {
+		if !f.Allowed(name) {
+			return fmt.Errorf("flag %q cannot be set from configuration", name)
+		}
+		return set(name, value)
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/alecthomas/chroma/v2 v2.4.0
 	github.com/andybalholm/cascadia v1.3.1
+	github.com/peterbourgon/ff/v3 v3.3.0
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/net v0.5.0
 	golang.org/x/tools v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dlclark/regexp2 v1.4.0 h1:F1rxgk7p4uKjwIQxBs9oAXe5CqrXlCduYEJvrF4u93E=
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/peterbourgon/ff/v3 v3.3.0 h1:PaKe7GW8orVFh8Unb5jNHS+JZBwWUMa2se0HM6/BI24=
+github.com/peterbourgon/ff/v3 v3.3.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/help.go
+++ b/help.go
@@ -14,7 +14,7 @@ import (
 type Help string
 
 var (
-	//go:embed help/usage.txt
+	//go:embed help/default.txt
 	_defaultHelp string
 
 	//go:embed help/frontmatter.txt
@@ -26,14 +26,18 @@ var (
 	//go:embed help/highlight.txt
 	_highlightHelp string
 
+	//go:embed help/config.txt
+	_configHelp string
+
 	_usageHelp = firstLineOf(_defaultHelp)
 
 	_helpTopics = map[Help]string{
-		"usage":       _usageHelp,
+		"config":      _configHelp,
 		"default":     _defaultHelp,
 		"frontmatter": _frontmatterHelp,
-		"pkg-doc":     _packageDocHelp,
 		"highlight":   _highlightHelp,
+		"pkg-doc":     _packageDocHelp,
+		"usage":       _usageHelp,
 	}
 )
 

--- a/help/config.txt
+++ b/help/config.txt
@@ -1,0 +1,27 @@
+-config RC
+
+RC is a configuration file.
+By default, doc2go will try to read it from doc2go.rc, if present.
+
+Configuration files have the format:
+
+	option1 value1
+	option2 value2
+	# ...
+
+* each line is an option name, a space, and then the value
+* the option name must be a single word
+* the option value is the rest of the line
+* the '#' character starts a line comment
+
+Nearly every doc2go flag may be supplied as an option.
+
+For example:
+
+	# start at module root
+	home go.abhg.dev/doc2go
+
+	# include internal packages in listings
+	internal
+
+	highlight inline:tango

--- a/help/default.txt
+++ b/help/default.txt
@@ -34,6 +34,9 @@ OPTIONS
   -pkg-doc PATH=TEMPLATE
 	generate links for PATH and its children via TEMPLATE.
 	See -help=pkg-doc for more information.
+  -config RC
+	read configuration from the given file. Defaults to doc2go.rc.
+	See -help=config for more information.
   -tags TAG,...
 	list of comma-separated build tags.
   -debug[=FILE]

--- a/main.go
+++ b/main.go
@@ -59,8 +59,7 @@ func (cmd *mainCmd) Run(args []string) (exitCode int) {
 		if errors.Is(err, errHelp) {
 			return 0
 		}
-		// No need to print anything.
-		// cliParser.Parse prints messages.
+		fmt.Fprintln(cmd.Stderr, err)
 		return 1
 	}
 


### PR DESCRIPTION
Read configuration from a doc2go.rc using a very simple format
as defined in [ff.PlainParser][1].

  [1]: https://pkg.go.dev/github.com/peterbourgon/ff/v3#PlainParser

The configuration path may be changed with the `-config` flag.

Flags that alter execution mode (version, help, print-css, list-themes)
are not allowed inside configuration files.

Using configuration files also simplifies the Makefile for docs
by putting more of the flags in there.

Resolves #8
