### PR TITLE
ci/release: Fix release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         set -eou pipefail
         REF=${{ github.ref }}
-        echo "VERSION=${REF#refs/tags/v}" >> $GITHUB_ENV
+        echo "VERSION=${REF#refs/tags/v}" >> "$GITHUB_ENV"
 
     - name: Extract changelog
       run: |
@@ -49,7 +49,7 @@ jobs:
       with:
         distribution: goreleaser
         version: latest
-        args: release --rm-dist --release-notes ${{ github.workspace }}-CHANGELOG.txt
+        args: release --clean --release-notes ${{ github.workspace }}-CHANGELOG.txt
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         AUR_KEY: ${{ secrets.AUR_KEY }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -56,7 +56,3 @@ checksum:
 
 snapshot:
   name_template: "{{ incminor .Tag }}-dev"
-
-changelog:
-  # A commit log is not a changelog.
-  skip: true


### PR DESCRIPTION
goreleaser does not update release notes
if changelog.skip is true
even if `--release-notes` is passed.
Drop it to resolve the issue.

Related: https://github.com/abhinav/stitchmd/pull/54

Also, --rm-dist has been deprecated in favor of --clean.

Related: https://github.com/abhinav/stitchmd/pull/53
