### PR TITLE
fix(lint/typo): linter-settings => linters-settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - paralleltest
     - revive
 
-linter-settings:
+linters-settings:
   govet:
     enable:
       - niliness


### PR DESCRIPTION
The golangci-lint configuration is called linters-settings.
