### PR TITLE
lint: Drop paralleltest

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
   enable:
     - gofumpt
     - nolintlint
-    - paralleltest
     - revive
 
 linters-settings:

--- a/flags_test.go
+++ b/flags_test.go
@@ -187,10 +187,7 @@ func TestCLIParser(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // chdir
 func TestCLIParser_Config(t *testing.T) {
-	t.Parallel()
-
 	wd, err := os.Getwd()
 	require.NoError(t, err)
 
@@ -222,8 +219,6 @@ func TestCLIParser_Config(t *testing.T) {
 	})
 
 	t.Run("custom file", func(t *testing.T) {
-		t.Parallel()
-
 		cfgFile := filepath.Join(t.TempDir(), "config")
 		give := "embed true\nfrontmatter foo.tmpl\nhighlight tango\n"
 		require.NoError(t,


### PR DESCRIPTION
Enabling t.Parallel for all tests is not a good idea after all.
Enabling it for slow tests makes sense, but not for all tests.
