### PR TITLE
internal: Rename slices to sliceutil

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -16,7 +16,7 @@ import (
 	"go.abhg.dev/doc2go/internal/pathtree"
 	"go.abhg.dev/doc2go/internal/pathx"
 	"go.abhg.dev/doc2go/internal/relative"
-	"go.abhg.dev/doc2go/internal/slices"
+	"go.abhg.dev/doc2go/internal/sliceutil"
 )
 
 // Parser loads a package reference from disk
@@ -232,7 +232,7 @@ func (r *Generator) renderPackage(crumbs []html.Breadcrumb, t packageTree) (_ *r
 }
 
 func htmlSubpackages(from string, rpkgs []*renderedPackage) []html.Subpackage {
-	return slices.Transform(rpkgs, func(rpkg *renderedPackage) html.Subpackage {
+	return sliceutil.Transform(rpkgs, func(rpkg *renderedPackage) html.Subpackage {
 		// TODO: track this on packageTree?
 		relPath := relative.Path(from, rpkg.ImportPath)
 

--- a/internal/godoc/assemble.go
+++ b/internal/godoc/assemble.go
@@ -14,7 +14,7 @@ import (
 
 	"go.abhg.dev/doc2go/internal/gosrc"
 	"go.abhg.dev/doc2go/internal/highlight"
-	"go.abhg.dev/doc2go/internal/slices"
+	"go.abhg.dev/doc2go/internal/sliceutil"
 )
 
 // Linker generates links to the documentation for a specific package or
@@ -118,10 +118,10 @@ func (as *assembly) pkg(dpkg *doc.Package) *Package {
 		ImportPath: dpkg.ImportPath,
 		Import:     as.importFor(dpkg.Name, dpkg.ImportPath),
 		Synopsis:   dpkg.Synopsis(dpkg.Doc),
-		Constants:  slices.Transform(dpkg.Consts, as.val),
-		Variables:  slices.Transform(dpkg.Vars, as.val),
-		Types:      slices.Transform(dpkg.Types, as.typ),
-		Functions:  slices.Transform(dpkg.Funcs, as.fun),
+		Constants:  sliceutil.Transform(dpkg.Consts, as.val),
+		Variables:  sliceutil.Transform(dpkg.Vars, as.val),
+		Types:      sliceutil.Transform(dpkg.Types, as.typ),
+		Functions:  sliceutil.Transform(dpkg.Funcs, as.fun),
 	}
 }
 
@@ -183,10 +183,10 @@ func (as *assembly) typ(dtyp *doc.Type) *Type {
 		Name:      dtyp.Name,
 		Doc:       as.doc(dtyp.Doc),
 		Decl:      as.decl(dtyp.Decl),
-		Constants: slices.Transform(dtyp.Consts, as.val),
-		Variables: slices.Transform(dtyp.Vars, as.val),
-		Functions: slices.Transform(dtyp.Funcs, as.fun),
-		Methods: slices.Transform(dtyp.Methods, func(f *doc.Func) *Function {
+		Constants: sliceutil.Transform(dtyp.Consts, as.val),
+		Variables: sliceutil.Transform(dtyp.Vars, as.val),
+		Functions: sliceutil.Transform(dtyp.Funcs, as.fun),
+		Methods: sliceutil.Transform(dtyp.Methods, func(f *doc.Func) *Function {
 			fn := as.fun(f)
 			fn.RecvType = dtyp.Name
 			return fn

--- a/internal/gosrc/finder.go
+++ b/internal/gosrc/finder.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"go.abhg.dev/doc2go/internal/slices"
+	"go.abhg.dev/doc2go/internal/sliceutil"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -100,7 +100,7 @@ func (f *Finder) FindPackages(patterns ...string) ([]*PackageRef, error) {
 			continue
 		}
 
-		goFiles := slices.RemoveFunc(pkg.GoFiles,
+		goFiles := sliceutil.RemoveFunc(pkg.GoFiles,
 			func(path string) bool {
 				return !strings.HasSuffix(path, ".go")
 			})

--- a/internal/relative/relative.go
+++ b/internal/relative/relative.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"go.abhg.dev/doc2go/internal/slices"
+	"go.abhg.dev/doc2go/internal/sliceutil"
 )
 
 const (
@@ -52,7 +52,7 @@ func rel(delim, src, dst string) string {
 		dstParts = strings.Split(dst, delim)
 	}
 
-	srcParts, dstParts = slices.RemoveCommonPrefix(srcParts, dstParts)
+	srcParts, dstParts = sliceutil.RemoveCommonPrefix(srcParts, dstParts)
 
 	var sb strings.Builder
 	for range srcParts {

--- a/internal/slices/doc.go
+++ b/internal/slices/doc.go
@@ -1,2 +1,0 @@
-// Package slices contains generic functions for working with slices.
-package slices

--- a/internal/sliceutil/doc.go
+++ b/internal/sliceutil/doc.go
@@ -1,0 +1,3 @@
+// Package sliceutil contains generic functions for working with slices.
+// Use it to augment the std "slices" package.
+package sliceutil

--- a/internal/sliceutil/prefix.go
+++ b/internal/sliceutil/prefix.go
@@ -1,4 +1,4 @@
-package slices
+package sliceutil
 
 // RemoveCommonPrefix removes the shared prefix from the two provided slices,
 // returning what remains for each slice as the result.

--- a/internal/sliceutil/prefix_test.go
+++ b/internal/sliceutil/prefix_test.go
@@ -1,4 +1,4 @@
-package slices
+package sliceutil
 
 import (
 	"testing"

--- a/internal/sliceutil/remove.go
+++ b/internal/sliceutil/remove.go
@@ -1,4 +1,4 @@
-package slices
+package sliceutil
 
 // RemoveFunc removes items matching the given function
 // from the provided slice.

--- a/internal/sliceutil/remove_test.go
+++ b/internal/sliceutil/remove_test.go
@@ -1,4 +1,4 @@
-package slices
+package sliceutil
 
 import (
 	"testing"

--- a/internal/sliceutil/transform.go
+++ b/internal/sliceutil/transform.go
@@ -1,4 +1,4 @@
-package slices
+package sliceutil
 
 // Transform builds a slice by applying the provided function
 // to all elements in the given slice.

--- a/internal/sliceutil/transform_test.go
+++ b/internal/sliceutil/transform_test.go
@@ -1,4 +1,4 @@
-package slices
+package sliceutil
 
 import (
 	"strconv"


### PR DESCRIPTION
Rename 'slices' to 'sliceutil' to allow use of the std 'slices' package
without import conflicts.
