### PR TITLE
iotest: Add a better, line-buffered writer

### DIFF
--- a/integration/go.mod
+++ b/integration/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/andybalholm/cascadia v1.3.2
 	github.com/stretchr/testify v1.8.4
 	go.abhg.dev/container/ring v0.3.0
+	go.abhg.dev/doc2go v0.5.0
 	golang.org/x/net v0.18.0
 )
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/container/ring"
+	"go.abhg.dev/doc2go/internal/iotest"
 	"golang.org/x/net/html"
 )
 
@@ -77,9 +78,10 @@ func testIntegration(t *testing.T, args []string) {
 
 	args = append([]string{"-out=" + outDir, "-internal", "-debug"}, args...)
 
+	output := iotest.Writer(t)
 	cmd := exec.Command(*_doc2go, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = output
+	cmd.Stderr = output
 	cmd.Dir = *_rundir
 	require.NoError(t, cmd.Run())
 

--- a/internal/iotest/writer.go
+++ b/internal/iotest/writer.go
@@ -4,20 +4,86 @@ package iotest
 import (
 	"bytes"
 	"io"
+	"sync"
 	"testing"
 )
 
-var _newline = []byte("\n")
+// writer is an io.Writer that writes to a testing.T.
+type writer struct {
+	// t holds the subset of testing.TB
+	// that we are allowed to use.
+	//
+	// We're not storing testing.TB directly to ensure that
+	// we don't accidentally use other log methods.
+	t interface {
+		Logf(string, ...interface{})
+		Helper()
+	}
 
-// Writer builds an io.Writer that writes to the given testing.TB.
-func Writer(t testing.TB) io.Writer {
-	return &writer{t}
+	// Holds buffered text for the next write or flush
+	// if we haven't yet seen a newline.
+	buff bytes.Buffer
+	mu   sync.Mutex // guards buff
 }
 
-type writer struct{ t testing.TB }
+var _ io.Writer = (*writer)(nil)
 
-func (w *writer) Write(b []byte) (int, error) {
-	b = bytes.TrimSuffix(b, _newline)
-	w.t.Logf("%s", b)
-	return len(b), nil
+// Writer builds and returns an io.Writer that
+// writes messages to the given testing.TB.
+// It ensures that each line is logged separately.
+//
+// Any trailing buffered text that does not end with a newline
+// is flushed when the test finishes.
+//
+// The returned writer is safe for concurrent use
+// from multiple parallel tests.
+func Writer(t testing.TB) io.Writer {
+	w := writer{t: t}
+	t.Cleanup(w.flush)
+	return &w
+}
+
+func (w *writer) Write(bs []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.t.Helper() // so that the log message points to the caller
+
+	// t.Logf adds a newline so we should not write bs as-is.
+	// Instead, we'll call t.Log one line at a time.
+	//
+	// To handle the case when Write is called with a partial line,
+	// we use a buffer.
+	total := len(bs)
+	for len(bs) > 0 {
+		idx := bytes.IndexByte(bs, '\n')
+		if idx < 0 {
+			// No newline. Buffer it for later.
+			w.buff.Write(bs)
+			break
+		}
+
+		var line []byte
+		line, bs = bs[:idx], bs[idx+1:]
+
+		if w.buff.Len() == 0 {
+			// Nothing buffered from a prior partial write.
+			// This is the majority case.
+			w.t.Logf("%s", line)
+			continue
+		}
+
+		// There's a prior partial write. Join and flush.
+		w.buff.Write(line)
+		w.t.Logf("%s", w.buff.String())
+		w.buff.Reset()
+	}
+	return total, nil
+}
+
+// flush flushes buffered text, even if it doesn't end with a newline.
+func (w *writer) flush() {
+	if w.buff.Len() > 0 {
+		w.t.Logf("%s", w.buff.String())
+	}
 }

--- a/internal/iotest/writer_test.go
+++ b/internal/iotest/writer_test.go
@@ -1,35 +1,127 @@
 package iotest
 
 import (
-	"bytes"
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type fakeT struct {
-	*testing.T
-
-	Buffer bytes.Buffer
-}
-
-func (t *fakeT) Logf(msg string, args ...interface{}) {
-	fmt.Fprintln(&t.Buffer, fmt.Sprintf(msg, args...))
-	// println to make sure it ends with a newline
-}
-
 func TestWriter(t *testing.T) {
 	t.Parallel()
 
-	fakeT := fakeT{T: t}
+	tests := []struct {
+		desc string
+
+		writes []string // individual write calls
+		want   []string // expected log output
+	}{
+		{
+			desc:   "empty strings",
+			writes: []string{"", "", ""},
+		},
+		{
+			desc:   "no newline",
+			writes: []string{"foo", "bar", "baz"},
+			want:   []string{"foobarbaz"},
+		},
+		{
+			desc: "newline separated",
+			writes: []string{
+				"foo\n",
+				"bar\n",
+				"baz\n\n",
+				"qux",
+			},
+			want: []string{
+				"foo",
+				"bar",
+				"baz",
+				"",
+				"qux",
+			},
+		},
+		{
+			desc:   "partial line",
+			writes: []string{"foo", "bar\nbazqux"},
+			want: []string{
+				"foobar",
+				"bazqux",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+
+			fakeT := fakeT{TB: t}
+			w := Writer(&fakeT)
+
+			for _, input := range tt.writes {
+				n, err := w.Write([]byte(input))
+				assert.NoError(t, err)
+				assert.Equal(t, len(input), n)
+			}
+
+			fakeT.runCleanup()
+
+			assert.Equal(t, tt.want, fakeT.msgs)
+		})
+	}
+}
+
+// Ensures that there are no data races in Writer
+// by writing to it from multiple concurrent goroutines.
+// 'go test -race' will explode if there's a data race.
+func TestWriterRace(t *testing.T) {
+	t.Parallel()
+
+	const N = 100 // number of concurrent writers
+
+	fakeT := fakeT{TB: t}
 	w := Writer(&fakeT)
-	_, err := io.WriteString(w, "foo")
-	require.NoError(t, err)
-	assert.Equal(t, "foo\n", fakeT.Buffer.String())
-	// If we wanted this to be more accurate, we would have it buffer
-	// the input on newlines simillar to the log-based io.Writer.
-	// It doesn't matter here.
+
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+
+			_, err := io.WriteString(w, "foo\n")
+			require.NoError(t, err)
+			_, err = io.WriteString(w, "bar\n")
+			require.NoError(t, err)
+			_, err = io.WriteString(w, "baz\n")
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+}
+
+// Wraps a testing.TB and intercepts log messages.
+type fakeT struct {
+	testing.TB
+
+	msgs     []string
+	cleanups []func()
+}
+
+func (t *fakeT) Logf(msg string, args ...interface{}) {
+	t.msgs = append(t.msgs, fmt.Sprintf(msg, args...))
+}
+
+func (t *fakeT) Cleanup(f func()) {
+	t.cleanups = append(t.cleanups, f)
+}
+
+func (t *fakeT) runCleanup() {
+	// cleanup functions are called in reverse order.
+	for i := len(t.cleanups) - 1; i >= 0; i-- {
+		t.cleanups[i]()
+	}
 }


### PR DESCRIPTION
This is a copy of what I've added to several other projects.
It reproduces the original input in the `t.Log` almost exactly.

The old version was also contractually incorrect:
it returned fewer bytes than were provided,
so the caller assumed a broken write.
This is why it wasn't usable with the integration test.
This remedies that as well.
