### PR TITLE
ci: Drop separate build step in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,6 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
         cache: true
 
-    - name: Build
-      run: make build
-      shell: bash
-
     - name: Test
       run: make cover
       shell: bash
@@ -67,10 +63,6 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
         cache: true
-
-    - name: Build
-      run: make build
-      shell: bash
 
     - name: Test
       run: make cover-integration


### PR DESCRIPTION
The unit tests already verify that everything can be compiled
and the integration tests build the binary from scratch.
There's no need to `make build` separately in CI.
