### PR TITLE
docs: List supported configuration keys

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,8 @@ STANDALONE_REF = content/en/example/index.html
 DEPS = \
 	standalone \
 	embedded \
-	assets/scss/_chroma.scss
+	assets/scss/_chroma.scss \
+	content/en/docs/usage/config-keys.txt
 
 .PHONY: build
 build: $(DEPS)
@@ -37,6 +38,9 @@ $(EMBEDDED_REF): $(DOC2GO) frontmatter.tmpl
 
 assets/scss/_chroma.scss: $(DOC2GO)
 	$(DOC2GO) -highlight=tango -highlight-print-css > $@
+
+content/en/docs/usage/config-keys.txt: $(DOC2GO)
+	$(DOC2GO) -print-config-keys > $@
 
 $(DOC2GO): doc2go.force
 	make -C .. bin/doc2go

--- a/docs/assets/scss/_chroma.scss
+++ b/docs/assets/scss/_chroma.scss
@@ -6,8 +6,8 @@
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
 /* LineHighlight */ .chroma .hl { background-color: #dfdfdf }
-/* LineNumbersTable */ .chroma .lnt { white-space: pre; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
-/* LineNumbers */ .chroma .ln { white-space: pre; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* Line */ .chroma .line { display: flex; }
 /* Keyword */ .chroma .k { color: #204a87; font-weight: bold }
 /* KeywordConstant */ .chroma .kc { color: #204a87; font-weight: bold }

--- a/docs/content/en/docs/usage/config-keys.txt
+++ b/docs/content/en/docs/usage/config-keys.txt
@@ -1,0 +1,12 @@
+basename
+config
+debug
+embed
+frontmatter
+highlight
+home
+internal
+out
+pkg-doc
+rel-link-style
+tags

--- a/docs/content/en/docs/usage/config.md
+++ b/docs/content/en/docs/usage/config.md
@@ -70,3 +70,12 @@ your embedded versus standalone sites, for example.
 doc2go -config embedded.rc ./...
 doc2go -config standalone.rc ./...
 ```
+
+## Supported configuration parameters
+
+The following may be specified via configuration:
+
+{{< readfile file="config-keys.txt" code="true" lang="plain" >}}
+
+See the [CLI Reference]({{< relref "/docs/usage#cli-reference" >}})
+for usage details for each of them.


### PR DESCRIPTION
List supported configuration keys in the documentation website.
Add a hidden -print-config-keys flag to do this.
