### PR TITLE
Respect -rel-link-style=directory for code links

### DIFF
--- a/.changes/unreleased/Fixed-20231110-202429.yaml
+++ b/.changes/unreleased/Fixed-20231110-202429.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix -rel-link-style being ignored for links inside source code blocks.
+time: 2023-11-10T20:24:29.528072159-08:00

--- a/integration/testdata/self.json
+++ b/integration/testdata/self.json
@@ -1,3 +1,0 @@
-["./..."]
-["-home=go.abhg.dev", "./..."]
-["-home", "go.abhg.dev/doc2go", "./..."]

--- a/integration/testdata/testify.json
+++ b/integration/testdata/testify.json
@@ -1,2 +1,0 @@
-["github.com/stretchr/testify/..."]
-["-home", "github.com/stretchr/testify/assert", "github.com/stretchr/testify/..."]

--- a/integration/testdata/xnet.json
+++ b/integration/testdata/xnet.json
@@ -1,3 +1,0 @@
-["golang.org/x/net/..."]
-["-home=golang.org/x/net", "golang.org/x/net/..."]
-["-rel-link-style=directory", "golang.org/x/net/..."]

--- a/link.go
+++ b/link.go
@@ -13,6 +13,8 @@ import (
 type docLinker struct {
 	knownImports map[string]struct{}
 	templates    pathtree.Root[*template.Template]
+
+	RelLinkStyle relLinkStyle
 }
 
 // LocalPackage marks an import path as a "local" package.
@@ -34,7 +36,7 @@ func (rl *docLinker) Template(path string, tmpl *template.Template) {
 
 func (rl *docLinker) packageDocURL(fromPkg, pkg string) string {
 	if _, ok := rl.knownImports[pkg]; ok {
-		return relative.Path(fromPkg, pkg)
+		return rl.RelLinkStyle.Normalize(relative.Path(fromPkg, pkg))
 	}
 
 	if tmpl, ok := rl.templates.Lookup(pkg); ok {

--- a/main.go
+++ b/main.go
@@ -146,7 +146,9 @@ func (cmd *mainCmd) run(opts *params) error {
 		pkgRefs = refs
 	}
 
-	var linker docLinker
+	linker := docLinker{
+		RelLinkStyle: opts.RelLinkStyle,
+	}
 	for _, lt := range opts.PkgDocs {
 		t, err := template.New(lt.Path).Parse(lt.Template)
 		if err != nil {


### PR DESCRIPTION
When we added support for -rel-link-style,
only links generated by the HTML package directly were updated.
We missed links generated inside code samples.

This fixes those links by plumbing RelLinkStyle to docLinker,
and using it to normalize them.

Adds an integration test to verify that all relative links
in the generated HTML have a trailing '/' with this flag
and can still be visited.

Resolves #154
