### PR TITLE
frontmatter: Add '.Name' helper

### DIFF
--- a/.changes/unreleased/Added-20231112-220506.yaml
+++ b/.changes/unreleased/Added-20231112-220506.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Frontmatter templates may now use `.Name` to handle the various title selection cases.
+time: 2023-11-12T22:05:06.672722-08:00

--- a/docs/content/en/docs/embed/hugo.md
+++ b/docs/content/en/docs/embed/hugo.md
@@ -73,13 +73,7 @@ Be sure to add  the `---` delimiters at the start and end of the template.
 #### Page title
 
 ```
-title: "
-  {{- with .Package.Name -}}
-    {{ if ne . "main" }}{{ . }}{{ else }}{{ $.Basename }}{{ end }}
-  {{- else -}}
-    {{ with .Basename }}{{ . }}{{ else }}Reference{{ end }}
-  {{- end -}}
-"
+title: "{{ with .Name }}{{ . }}{{ else }}Reference{{ end }}"
 ```
 
 This gives us a title based on the package or binary name,

--- a/docs/content/en/docs/embed/jekyll.md
+++ b/docs/content/en/docs/embed/jekyll.md
@@ -31,13 +31,7 @@ to the docs directory:
 ```bash
 cat > docs/frontmatter.tmpl << EOF
 ---
-title: "
-  {{- with .Package.Name -}}
-    {{ if ne . "main" }}{{ . }}{{ else }}{{ $.Basename }}{{ end }}
-  {{- else -}}
-    {{ with .Basename }}{{ . }}{{ else }}Reference{{ end }}
-  {{- end -}}
-"
+title: "{{ with .Name }}{{ . }}{{ else }}Reference{{ end }}"
 layout: default
 render_with_liquid: false
 ---

--- a/docs/content/en/docs/usage/frontmatter.md
+++ b/docs/content/en/docs/usage/frontmatter.md
@@ -86,85 +86,21 @@ with a `title` attribute in the front matter.
 You can use the following template
 to set the page title accurately for most cases.
 
-
 {{< tabpane persistLang=false >}}
 {{< tab header="YAML" lang="plain" >}}
-title: "
-  {{- with .Package.Name -}}
-    {{ if ne . "main" }}{{ . }}{{ else }}{{ $.Basename }}{{ end }}
-  {{- else -}}
-    {{ with .Basename }}{{ . }}{{ else }}Reference{{ end }}
-  {{- end -}}
-"
+title: "{{ with .Name }}{{ . }}{{ else }}Reference{{ end }}"
 {{< /tab >}}
 {{< tab header="TOML" lang="plain" >}}
-title = "
-  {{- with .Package.Name -}}
-    {{ if ne . "main" }}{{ . }}{{ else }}{{ $.Basename }}{{ end }}
-  {{- else -}}
-    {{ with .Basename }}{{ . }}{{ else }}Reference{{ end }}
-  {{- end -}}
-"
+title = "{{ with .Name }}{{ . }}{{ else }}Reference{{ end }}"
 {{< /tab >}}
 {{< /tabpane >}}
 
-It handles a few different cases.
-Let's reformat it and walk through it:
+This handles a few different cases:
 
-```
-  {{- with .Package.Name -}}
-    {{ if ne . "main" -}}
-      {{ . }}
-    {{- else -}}
-      {{ $.Basename }}
-    {{- end }}
-  {{- else -}}
-    {{ with .Basename -}}
-      {{ . }}
-    {{- else -}}
-      Reference
-    {{- end }}
-  {{- end -}}
-```
-
-- If we're looking at a Go package,
-  and it's not a binary, use the name of the package.
-
-    ```
-    {{- with .Package.Name -}}
-      {{ if ne . "main" -}}
-        {{ . }}
-    ```
-
-- If the package is a binary,
-  use the name of the binary---determined by the base name.
-
-    ```
-      {{- else -}}
-        {{ $.Basename }}
-      {{- end }}
-    ```
-
-- If we're looking at a directory, not a Go package,
-  and it's not the top-level directory,
-  use the base name of the directory.
-
-    ```
-    {{- else -}}
-      {{ with .Basename -}}
-        {{ . }}
-    ```
-
-- If we're looking at the top-level directory,
-  use the title "API Reference"
-  since this is the entry point to the generated API reference.
-
-    ```
-      {{- else -}}
-        Reference
-      {{- end }}
-    {{- end -}}
-    ```
+- for non-main packages, use the name of the package
+- for main packages, use the name of the binary---determined by the base name
+- for directories that aren't Go packages, use the name of the directory
+- lastly, for the top-level directory, use the title "Reference"
 
 ## Page description
 
@@ -211,5 +147,8 @@ struct {
 		// if any.
 		Synopsis string
 	}
+
+	// Name of this package or directory.
+	Name string
 }
 ```

--- a/docs/frontmatter.tmpl
+++ b/docs/frontmatter.tmpl
@@ -1,11 +1,5 @@
 ---
-title: "
-  {{- with .Package.Name -}}
-    {{ if ne . "main" }}{{ . }}{{ else }}{{ $.Basename }}{{ end }}
-  {{- else -}}
-    {{ with .Basename }}{{ . }}{{ else }}Reference{{ end }}
-  {{- end -}}
-"
+title: "{{ with .Name }}{{ . }}{{ else }}Reference{{ end }}"
 no_list: true
 type: docs
 github_repo: "https://github.com/abhinav/doc2go"

--- a/internal/html/render.go
+++ b/internal/html/render.go
@@ -143,6 +143,16 @@ type frontmatterData struct {
 	Package     frontmatterPackageData
 }
 
+func (d frontmatterData) Name() string {
+	if n := d.Package.Name; n != "" && n != "main" {
+		return n
+	}
+	if d.Basename != "" {
+		return d.Basename
+	}
+	return ""
+}
+
 func (r *Renderer) renderFrontmatter(w io.Writer, d frontmatterData) error {
 	if r.FrontMatter == nil {
 		return nil

--- a/internal/html/render_test.go
+++ b/internal/html/render_test.go
@@ -806,6 +806,48 @@ func TestBasename(t *testing.T) {
 	}
 }
 
+func TestFrontmatterDataName(t *testing.T) {
+	tests := []struct {
+		desc string
+		data frontmatterData
+		want string
+	}{
+		{desc: "empty"},
+		{
+			desc: "package",
+			data: frontmatterData{
+				Package: frontmatterPackageData{
+					Name: "foo",
+				},
+			},
+			want: "foo",
+		},
+		{
+			desc: "main package",
+			data: frontmatterData{
+				Package: frontmatterPackageData{
+					Name: "main",
+				},
+				Basename: "bar",
+			},
+			want: "bar",
+		},
+		{
+			desc: "dir",
+			data: frontmatterData{
+				Basename: "baz",
+			},
+			want: "baz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.data.Name())
+		})
+	}
+}
+
 func TestDict(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
Right now, frontmatter templates have to use this messy template
to pick the correct title for various cases:

    title: "
      {{- with .Package.Name -}}
        {{ if ne . "main" }}{{ . }}{{ else }}{{ $.Basename }}{{ end }}
      {{- else -}}
        {{ with .Basename }}{{ . }}{{ else }}Reference{{ end }}
      {{- end -}}
    "

Add a `.Name` to the context that implements this logic
so that it may be shortened to:

    title: "{{ .Name }}"

Resolves #70
