### PR TITLE
Hide deprecated objects by default

### DIFF
--- a/.changes/unreleased/Changed-20231114-060755.yaml
+++ b/.changes/unreleased/Changed-20231114-060755.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Standalone website shows deprecated elements as collapsed by default.
+time: 2023-11-14T06:07:55.986124-08:00

--- a/internal/html/static/css/main.css
+++ b/internal/html/static/css/main.css
@@ -60,4 +60,18 @@ details.example > summary {
   cursor: pointer;
 }
 
+details.deprecated > summary {
+  list-style: none;
+}
+
+span.deprecated-tag {
+  color: #eee;
+  background-color: #999;
+  padding: 0.125rem 0.3rem;
+  border-radius: 0.3rem;
+  font-size: 0.7rem;
+  vertical-align: middle;
+  cursor: pointer;
+}
+
 #generated-by-footer { font-size: x-small; }

--- a/internal/html/static/js/permalink.js
+++ b/internal/html/static/js/permalink.js
@@ -9,12 +9,20 @@ function openDetailsAnchor() {
 	if (!el) {
 		return
 	}
-	if (el.tagName == "DETAILS") {
-		el.open = true
+
+	let details = el.closest("details")
+	while (details) {
+		details.open = true
+		details = details.parentElement.closest("details")
 	}
+
+	// New elements may have appeared.
+	// Set hash again to scroll to the right place.
+	window.location.hash = hash;
+	return false;
 }
 
-window.addEventListener('hashchange', () => openDetailsAnchor())
+window.addEventListener('hashchange', openDetailsAnchor)
 
 window.addEventListener('load', () => {
 	document.querySelectorAll("h2, h3, h4, h5, h6").forEach((el) => {

--- a/internal/html/tmpl/package.html
+++ b/internal/html/tmpl/package.html
@@ -18,18 +18,18 @@
   {{ if .Constants }}<li><a href="#pkg-constants">Constants</a></li>{{ end -}}
   {{ if .Variables }}<li><a href="#pkg-variables">Variables</a></li>{{ end -}}
   {{ range .Functions -}}
-    <li><a href="#{{ .Name }}">{{ .ShortDecl }}</a></li>
+    <li><a href="#{{ .Name }}">{{ .ShortDecl }}</a>{{ template "deprecatedTag" . }}</li>
   {{ end -}}
   {{ range $typ := .Types -}}
     <li>
-      <a href="#{{ .Name }}">type {{ .Name }}</a>
+      <a href="#{{ .Name }}">type {{ .Name }}</a>{{ template "deprecatedTag" . }}
       {{ if or .Functions .Methods -}}
         <ul>
           {{ range .Functions -}}
-            <li><a href="#{{ .Name }}">{{ .ShortDecl }}</a></li>
+            <li><a href="#{{ .Name }}">{{ .ShortDecl }}</a>{{ template "deprecatedTag" . }}</li>
           {{ end -}}
           {{ range .Methods -}}
-            <li><a href="#{{ $typ.Name }}.{{ .Name }}">{{ .ShortDecl }}</a></li>
+            <li><a href="#{{ $typ.Name }}.{{ .Name }}">{{ .ShortDecl }}</a>{{ template "deprecatedTag" . }}</li>
           {{ end -}}
         </ul>
       {{ end -}}
@@ -64,17 +64,22 @@
 {{ with .Functions -}}
   <h3 id="pkg-functions">Functions</h3>
   {{ range . -}}
-    <h3 id="{{ .Name }}">func {{ .Name }}</h3>
+    {{ if .Deprecated }}<details class="deprecated"><summary>{{ end -}}
+      <h3 id="{{ .Name }}">func {{ .Name }} {{- template "deprecatedTag" . }}</h3>
+    {{- if .Deprecated }}</summary>{{ end }}
     {{ .Decl | code }}
     {{ .Doc | doc 4 -}}
     {{ template "examples" (dict "Level" 4 "Examples" .Examples) -}}
+    {{- if .Deprecated }}</details>{{ end -}}
   {{ end -}}
 {{ end -}}
 
 {{ with .Types -}}
   <h3 id="pkg-types">Types</h3>
   {{ range . -}}
-  <h3 id="{{ .Name }}">type {{ .Name }}</h3>
+    {{ if .Deprecated }}<details class="deprecated"><summary>{{ end -}}
+    <h3 id="{{ .Name }}">type {{ .Name }} {{- template "deprecatedTag" . }}</h3>
+    {{- if .Deprecated }}</summary>{{ end }}
     {{ .Decl | code }}
     {{ .Doc | doc 4 -}}
     {{ template "examples" (dict "Level" 4 "Examples" .Examples) -}}
@@ -94,6 +99,7 @@
     {{ range .Methods -}}
       {{ template "funcOrMethod" . -}}
     {{ end -}}
+    {{- if .Deprecated }}</details>{{ end -}}
   {{ end -}}
 {{ end -}}
 
@@ -110,10 +116,13 @@
 {{- define "funcOrMethod" -}}
   {{ $id := .Name -}}
   {{ with .RecvType }}{{ $id = printf "%s.%s" . $id }}{{ end -}}
-  <h4 id="{{ $id }}">func {{ with .Recv }}({{ . }}) {{end }}{{ .Name }}</h4>
+  {{ if .Deprecated }}<details class="deprecated"><summary>{{ end -}}
+    <h4 id="{{ $id }}">func {{ with .Recv }}({{ . }}) {{end }}{{ .Name }} {{- template "deprecatedTag" . }}</h4>
+  {{- if .Deprecated }}</summary>{{ end }}
   {{ .Decl | code }}
   {{ .Doc | doc 5 -}}
   {{ template "examples" (dict "Level" 5 "Examples" .Examples) -}}
+  {{- if .Deprecated }}</details>{{ end -}}
 {{- end -}}
 
 {{- define "examples" -}}
@@ -134,3 +143,7 @@
     </details>
   {{ end -}}
 {{- end -}}
+
+{{- define "deprecatedTag" -}}
+{{ if .Deprecated }} <span class="deprecated-tag">deprecated</span>{{ end -}}
+{{ end -}}


### PR DESCRIPTION
Matching the behavior of pkg.go.dev,
if a type, function, or method is deprecated,
show it in a collapsed `<details>` section.

Resolves #19
