### PR TITLE
Add -subdir option for versioned documentation

### DIFF
--- a/.changes/unreleased/Added-20240119-155752.yaml
+++ b/.changes/unreleased/Added-20240119-155752.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Initial support for versioned documentation with -subdir. Thanks to @3052.
+time: 2024-01-19T15:57:52.811371-05:00

--- a/flags.go
+++ b/flags.go
@@ -35,6 +35,7 @@ type params struct {
 
 	Basename  string
 	OutputDir string
+	TagDir    string
 	Home      string
 
 	Embed        bool
@@ -70,6 +71,7 @@ func (cmd *cliParser) newFlagSet(cfg *configFileParser) (*params, *flag.FlagSet)
 
 	// Filesystem:
 	flag.StringVar(&p.OutputDir, "out", "_site", "")
+	flag.StringVar(&p.TagDir, "tag", "", "")
 	flag.StringVar(&p.Basename, "basename", "", "")
 	flag.StringVar(&p.Home, "home", "", "")
 

--- a/flags_test.go
+++ b/flags_test.go
@@ -161,6 +161,16 @@ func TestCLIParser(t *testing.T) {
 			},
 		},
 		{
+			desc: "subdir",
+			give: []string{"-subdir", "v1.0.0", "./..."},
+			want: params{
+				Config:    "doc2go.rc",
+				SubDir:    "v1.0.0",
+				Patterns:  []string{"./..."},
+				OutputDir: "_site",
+			},
+		},
+		{
 			desc: "list themes",
 			give: []string{"-highlight-list-themes"},
 			want: params{
@@ -318,6 +328,11 @@ func TestCLIParser_Errors(t *testing.T) {
 			desc: "bad highlight mode",
 			give: []string{"-highlight", "foo:bar"},
 			want: `unrecognized highlight mode "foo"`,
+		},
+		{
+			desc: "subdir with /",
+			give: []string{"-subdir", "foo/bar", "./..."},
+			want: "must not contain path separators",
 		},
 	}
 

--- a/generate.go
+++ b/generate.go
@@ -116,11 +116,11 @@ func (r *Generator) Generate(pkgRefs []*gosrc.PackageRef) error {
 		}
 		idx := html.PackageIndex{Path: r.Home}
 		for _, entry := range entries {
-			switch name := entry.Name(); name {
-			case html.StaticDir, r.Basename:
-			default:
-				sub := html.Subpackage{RelativePath: name}
-				idx.Subpackages = append(idx.Subpackages, sub)
+			if entry.IsDir() {
+				if name := entry.Name(); name != html.StaticDir {
+					sub := html.Subpackage{RelativePath: name}
+					idx.Subpackages = append(idx.Subpackages, sub)
+				}
 			}
 		}
 		f, err := os.Create(filepath.Join(r.OutDir, r.Basename))

--- a/help/default.txt
+++ b/help/default.txt
@@ -12,8 +12,10 @@ OPTIONS
 	base name of generated files. Defaults to index.html.
   -out DIR
 	write files to DIR. Defaults to _site.
-  -tag DIR
-	optional subfolder of -out
+  -subdir NAME
+	generate output to DIR/NAME instead of DIR.
+	An index of siblings of NAME will be generated in DIR.
+	Use for generating versioned documentation.
   -home PATH
 	import path for the home page of the documentation.
 	Packages that aren't descendants of this path will be omitted.

--- a/help/default.txt
+++ b/help/default.txt
@@ -12,6 +12,8 @@ OPTIONS
 	base name of generated files. Defaults to index.html.
   -out DIR
 	write files to DIR. Defaults to _site.
+  -tag DIR
+	optional subfolder of -out
   -home PATH
 	import path for the home page of the documentation.
 	Packages that aren't descendants of this path will be omitted.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -98,13 +98,13 @@ func TestDirectoryRelativeLinks(t *testing.T) {
 	})
 }
 
-// Verifies that multiple runs with different tags
+// Verifies that multiple runs with different -subdir
 // generate a shared root index page.
-func TestVersionIndex(t *testing.T) {
+func TestOutputSubdir(t *testing.T) {
 	t.Parallel()
 
-	outDir := generate(t, "-tag=v1.1.0", "./...")
-	generate(t, "-tag=v1.2.3", "-out="+outDir, "./...")
+	outDir := generate(t, "-subdir=v1.1.0", "./...")
+	generate(t, "-subdir=v1.2.3", "-out="+outDir, "./...")
 
 	// Verify that we hit /v1.1.0/ and /v1.2.3/
 	roots := make(map[string]struct{})

--- a/internal/html/render.go
+++ b/internal/html/render.go
@@ -20,6 +20,8 @@ import (
 	"go.abhg.dev/doc2go/internal/relative"
 )
 
+// StaticDir is the name of the directory in the output
+// where static files are stored.
 const StaticDir = "_"
 
 var (

--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func (cmd *mainCmd) run(opts *params) error {
 			NormalizeRelativePath: opts.RelLinkStyle.Normalize,
 		},
 		OutDir:    opts.OutputDir,
-		TagDir:    opts.TagDir,
+		SubDir:    opts.SubDir,
 		Basename:  opts.Basename,
 		DocLinker: &linker,
 	}

--- a/main.go
+++ b/main.go
@@ -191,6 +191,7 @@ func (cmd *mainCmd) run(opts *params) error {
 			NormalizeRelativePath: opts.RelLinkStyle.Normalize,
 		},
 		OutDir:    opts.OutputDir,
+		TagDir:    opts.TagDir,
 		Basename:  opts.Basename,
 		DocLinker: &linker,
 	}


### PR DESCRIPTION
Adds a `-subdir` flag to doc2go.
If specified, documentation will be generated under `$out/$sub`,
where `$out` is the output directory per `-out`.

Further, with this flag present,
we'll generate an index at `$out/index.html` of the siblings of `$sub`,
allowing this to generate versioned documentation.
For example:

    git checkout v1.2.3
    doc2go -subdir v1.2.3 ./...
    git checkout v1.5.0
    doc2go -subdir v1.5.0 ./...

This will result in a `_site/index.html` that points to
`_site/v1.2.3/` and `_site/v1.5.0/`, both of which have the full documentation
for the package at that point in time.
The static assets are shared between all websites.

Resolves #76