### PR TITLE
html/render: exhaustive internal handling

### DIFF
--- a/.changes/unreleased/Fixed-20240119-231536.yaml
+++ b/.changes/unreleased/Fixed-20240119-231536.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix some internal packages still being listed without -internal. Thanks to @3052.
+time: 2024-01-19T23:15:36.036143-05:00

--- a/internal/html/render.go
+++ b/internal/html/render.go
@@ -366,24 +366,20 @@ func (r *render) filterSubpackages(pkgs []Subpackage) []Subpackage {
 		return pkgs
 	}
 
-	internal := func(s string) bool {
-		switch {
-		case s == "internal":
-			return true
-		case strings.HasPrefix(s, "internal/"):
-			return true
-		case strings.Contains(s, "/internal/"):
-			return true
-		}
-		return false
-	}
 	filtered := make([]Subpackage, 0, len(pkgs))
 	for _, pkg := range pkgs {
-		if !internal(pkg.RelativePath) {
+		if !isInternal(pkg.RelativePath) {
 			filtered = append(filtered, pkg)
 		}
 	}
 	return filtered
+}
+
+func isInternal(relpath string) bool {
+	return relpath == "internal" ||
+		strings.HasPrefix(relpath, "internal/") ||
+		strings.HasSuffix(relpath, "/internal") ||
+		strings.Contains(relpath, "/internal/")
 }
 
 // dict turns key-value pairs into a map.

--- a/internal/html/render.go
+++ b/internal/html/render.go
@@ -366,13 +366,22 @@ func (r *render) filterSubpackages(pkgs []Subpackage) []Subpackage {
 		return pkgs
 	}
 
+	internal := func(s string) bool {
+		switch {
+		case s == "internal":
+			return true
+		case strings.HasPrefix(s, "internal/"):
+			return true
+		case strings.Contains(s, "/internal/"):
+			return true
+		}
+		return false
+	}
 	filtered := make([]Subpackage, 0, len(pkgs))
 	for _, pkg := range pkgs {
-		relPath := pkg.RelativePath
-		if relPath == "internal" || strings.HasPrefix(relPath, "internal/") {
-			continue
+		if !internal(pkg.RelativePath) {
+			filtered = append(filtered, pkg)
 		}
-		filtered = append(filtered, pkg)
 	}
 	return filtered
 }

--- a/internal/html/render_test.go
+++ b/internal/html/render_test.go
@@ -891,6 +891,27 @@ func TestDictErrors(t *testing.T) {
 	})
 }
 
+func TestIsInternal(t *testing.T) {
+	tests := []struct {
+		give string
+		want bool
+	}{
+		{"internal", true},
+		{"internal/foo", true},
+		{"foo/internal", true},
+		{"foo/internal/bar", true},
+		{"internalfoo", false},
+		{"foo/internalfoo", false},
+		{"internalfoo/bar", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.give, func(t *testing.T) {
+			assert.Equal(t, tt.want, isInternal(tt.give))
+		})
+	}
+}
+
 func querySelector(n *html.Node, query string) *html.Node {
 	return cascadia.Query(n, cascadia.MustCompile(query))
 }


### PR DESCRIPTION
Current filter misses packages such as: go/internal/gcimporter.
This fixes filtering to ignore packages that are named internal,
inside internal, or contain /internal/.

Resolves #176