### PR TITLE
gosrc/finder: omit vendor packages

### DIFF
--- a/.changes/unreleased/Fixed-20240119-232009.yaml
+++ b/.changes/unreleased/Fixed-20240119-232009.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Don't include vendor directories.
+time: 2024-01-19T23:20:09.634499-05:00

--- a/internal/gosrc/finder.go
+++ b/internal/gosrc/finder.go
@@ -92,6 +92,11 @@ func (f *Finder) FindPackages(patterns ...string) ([]*PackageRef, error) {
 
 	infos := make([]*PackageRef, 0, len(pkgs))
 	for _, pkg := range pkgs {
+		if strings.HasPrefix(pkg.PkgPath, "vendor/") {
+			f.Log.Printf("[%v] Skipping.", pkg.PkgPath)
+			continue
+		}
+
 		var pkgFailed bool
 		for _, err := range pkg.Errors {
 			pkgFailed = true

--- a/internal/gosrc/finder_test.go
+++ b/internal/gosrc/finder_test.go
@@ -50,6 +50,33 @@ func testFinder(t *testing.T, exporter packagestest.Exporter) {
 			},
 		},
 		{
+			desc: "skip vendor packages",
+			path: "example.com/foo",
+			files: map[string]any{
+				"foo.go":            "package foo",
+				"vendor/bar/baz.go": "package bar",
+				"bar/baz.go":        "package bar",
+			},
+			want: func(exported *packagestest.Exported) []*PackageRef {
+				return []*PackageRef{
+					{
+						Name:       "foo",
+						ImportPath: "example.com/foo",
+						Files: []string{
+							exported.File("example.com/foo", "foo.go"),
+						},
+					},
+					{
+						Name:       "bar",
+						ImportPath: "example.com/foo/bar",
+						Files: []string{
+							exported.File("example.com/foo", "bar/baz.go"),
+						},
+					},
+				}
+			},
+		},
+		{
 			desc: "build tagged file",
 			path: "example.com/bar",
 			tags: []string{"mytag"},


### PR DESCRIPTION
We should not include vendored code in output.
This matches expected behavior in:

- https://pkg.go.dev/std
- https://godocs.io/std

Fixes #178