### PR TITLE
standalone/navbar: add link to index section

### DIFF
--- a/.changes/unreleased/Changed-20240120-203417.yaml
+++ b/.changes/unreleased/Changed-20240120-203417.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'Standalone website: Include a link to the package index on top.'
+time: 2024-01-20T20:34:17.813655-05:00

--- a/internal/html/render_test.go
+++ b/internal/html/render_test.go
@@ -641,6 +641,7 @@ func TestRenderBreadcrumbs(t *testing.T) {
 		{"../../..", "example.com"},
 		{"../..", "foo"},
 		{"..", "bar"},
+		{"#pkg-index", "Index"},
 	}
 
 	assertCrumbs := func(t *testing.T, output []byte) {

--- a/internal/html/static/css/main.css
+++ b/internal/html/static/css/main.css
@@ -33,6 +33,10 @@ nav {
   padding: 1em;
   background-color: #eee;
   border-radius: 0.5em;
+  display: flex;
+}
+nav a {
+  margin-left: auto;
 }
 
 /* Remove first level of nesting for a package's index section. */

--- a/internal/html/tmpl/layout.html
+++ b/internal/html/tmpl/layout.html
@@ -19,6 +19,7 @@
             {{ $crumb.Text -}}
           {{ end -}}
         {{ end -}}
+        <a href="#pkg-index">Index</a>
       </nav>
     {{- end -}}
     <main>{{ template "Body" $ -}}</main>


### PR DESCRIPTION
In standalone mode, change the navbar to include a link
to the page's index.

Resolves #182