### PR TITLE
internal/html: make sure margin only applies to index link

### DIFF
--- a/internal/html/static/css/main.css
+++ b/internal/html/static/css/main.css
@@ -35,7 +35,7 @@ nav {
   border-radius: 0.5em;
   display: flex;
 }
-[href="#pkg-index"] {
+nav a[href="#pkg-index"] {
   margin-left: auto;
 }
 

--- a/internal/html/static/css/main.css
+++ b/internal/html/static/css/main.css
@@ -35,7 +35,7 @@ nav {
   border-radius: 0.5em;
   display: flex;
 }
-nav a {
+[href="#pkg-index"] {
   margin-left: auto;
 }
 


### PR DESCRIPTION
otherwise it shifts the breadcrumbs to the middle