### PR TITLE
standalone/navbar: Add "Root" link

### DIFF
--- a/.changes/unreleased/Added-20240121-152808.yaml
+++ b/.changes/unreleased/Added-20240121-152808.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: |-
+  Standalone: Add a "Root" link to the navbar, going to the top-level page.
+  With `-subdir`, this will be the sub-directory listing.
+time: 2024-01-21T15:28:08.567401-05:00

--- a/.changes/unreleased/Fixed-20240121-152840.yaml
+++ b/.changes/unreleased/Fixed-20240121-152840.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'Standalone: Don''t show "Index" link in navbar on pages without an Index.'
+time: 2024-01-21T15:28:40.781528-05:00

--- a/internal/html/render.go
+++ b/internal/html/render.go
@@ -317,10 +317,18 @@ type render struct {
 
 func (r *render) FuncMap() template.FuncMap {
 	return template.FuncMap{
-		"doc":               r.doc,
-		"code":              r.code,
-		"static":            r.static,
-		"relativePath":      r.relativePath,
+		"doc":          r.doc,
+		"code":         r.code,
+		"static":       r.static,
+		"relativePath": r.relativePath,
+		"relativeRootPath": func() string {
+			// "" is root unless we're in a subdirectory
+			var root string
+			if r.SubDirDepth > 0 {
+				root = strings.Repeat("../", r.SubDirDepth)
+			}
+			return r.relativePath(root)
+		},
 		"filterSubpackages": r.filterSubpackages,
 		"dict":              dict,
 		"normalizeRelativePath": func(p string) string {

--- a/internal/html/static/css/main.css
+++ b/internal/html/static/css/main.css
@@ -35,7 +35,8 @@ nav {
   border-radius: 0.5em;
   display: flex;
 }
-nav a[href="#pkg-index"] {
+
+nav .navbar-right {
   margin-left: auto;
 }
 

--- a/internal/html/tmpl/layout.html
+++ b/internal/html/tmpl/layout.html
@@ -23,7 +23,10 @@
             {{ $crumb.Text -}}
           {{ end -}}
         {{ end -}}
-        <a href="#pkg-index">Index</a>
+        <span class="navbar-right">
+          <a href="{{ relativeRootPath }}">Root</a>
+          {{- block "NavbarExtra" $ }}{{ end }}
+        </span>
       </nav>
     {{- end -}}
     <main>{{ template "Body" $ -}}</main>

--- a/internal/html/tmpl/package.html
+++ b/internal/html/tmpl/package.html
@@ -4,6 +4,8 @@
 </title>
 {{ end -}}
 
+{{ define "NavbarExtra" }} | <a href="#pkg-index">Index</a>{{ end -}}
+
 {{ define "Body" -}}
 <h2 id="pkg-overview">
   {{- with .BinName }}{{ . }}{{ else }}package {{ .Name }}{{ end -}}


### PR DESCRIPTION
Adds a link that goes to the root of the website to the navbar.
This link will point to the index.html inside OutDir, whatever that is.
By default, that's the top-level package listing.
With `-subdir`, that's the sibling directory listing.

In adding this, I discovered and fixed a bug
where an "Index" link would show even on directory listing pages
that had breadcrumbs.

Resolves #187
