### PR TITLE
internal/html/static/css: flex-wrap

### DIFF
--- a/internal/html/static/css/main.css
+++ b/internal/html/static/css/main.css
@@ -34,6 +34,7 @@ nav {
   background-color: #eee;
   border-radius: 0.5em;
   display: flex;
+  flex-wrap: wrap;
 }
 
 nav .navbar-right {


### PR DESCRIPTION
current layout is ugly on mobile:

> ![ugly](https://github.com/abhinav/doc2go/assets/147215885/d0a88b0b-251b-4fa4-9927-3d728f915c5d)

compared to GoDocs, which wraps:

> ![wrap](https://github.com/abhinav/doc2go/assets/147215885/6b5aaffa-513c-4c0a-9916-47e562de9c96)

this fix adds wrapping:

> ![fix](https://github.com/abhinav/doc2go/assets/147215885/07a2b4fa-40c3-45ff-a097-362e4910612b)