### PR TITLE
Instrument errors with errtrace

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -156,7 +156,7 @@ func (cmd *cliParser) Parse(args []string) (*params, error) {
 
 	if len(help) != 0 {
 		if err := help.Write(cmd.Stderr); err != nil {
-			fmt.Fprintln(cmd.Stderr, err)
+			fmt.Fprintf(cmd.Stderr, "%+v\n", err)
 		}
 
 		// For configuration,

--- a/flags_test.go
+++ b/flags_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"braces.dev/errtrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/doc2go/internal/iotest"
@@ -486,7 +487,7 @@ func TestConfigFileParser(t *testing.T) {
 		giveErr := errors.New("great sadness")
 		err := p.Parse(strings.NewReader("foo"),
 			func(k, v string) error {
-				return giveErr
+				return errtrace.Wrap(giveErr)
 			})
 		assert.ErrorIs(t, err, giveErr)
 	})

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.abhg.dev/doc2go
 go 1.22.0
 
 require (
+	braces.dev/errtrace v0.3.0
 	github.com/alecthomas/chroma/v2 v2.12.0
 	github.com/andybalholm/cascadia v1.3.2
 	github.com/peterbourgon/ff/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+braces.dev/errtrace v0.3.0 h1:pzfd6LcWgfWtXLaNFWRnxV/7NP+FSOlIjRLwDuHfPxs=
+braces.dev/errtrace v0.3.0/go.mod h1:YQpXdo+u5iimgQdZzFoic8AjedEDncXGpp6/2SfazzI=
 github.com/alecthomas/assert/v2 v2.2.1 h1:XivOgYcduV98QCahG8T5XTezV5bylXe+lBxLG2K2ink=
 github.com/alecthomas/assert/v2 v2.2.1/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
 github.com/alecthomas/chroma/v2 v2.12.0 h1:Wh8qLEgMMsN7mgyG8/qIpegky2Hvzr4By6gEF7cmWgw=

--- a/help.go
+++ b/help.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"sort"
 	"strings"
+
+	"braces.dev/errtrace"
 )
 
 // Help is doc2go's -h/-help flag.
@@ -57,7 +59,7 @@ func (h Help) Write(w io.Writer) error {
 
 	if doc, ok := _helpTopics[h]; ok {
 		_, err := io.WriteString(w, doc)
-		return err
+		return errtrace.Wrap(err)
 	}
 
 	topics := make([]string, 0, len(_helpTopics))
@@ -66,7 +68,7 @@ func (h Help) Write(w io.Writer) error {
 	}
 	sort.Strings(topics)
 
-	return fmt.Errorf("unknown help topic %q: valid values are %q", string(h), topics)
+	return errtrace.Wrap(fmt.Errorf("unknown help topic %q: valid values are %q", string(h), topics))
 }
 
 var _ flag.Getter = (*Help)(nil)

--- a/internal/errdefer/errdefer_test.go
+++ b/internal/errdefer/errdefer_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"braces.dev/errtrace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,5 +35,5 @@ type stubCloser struct {
 }
 
 func (s stubCloser) Close() error {
-	return s.err
+	return errtrace.Wrap(s.err)
 }

--- a/internal/errdefer/example_test.go
+++ b/internal/errdefer/example_test.go
@@ -4,18 +4,19 @@ import (
 	"io"
 	"os"
 
+	"braces.dev/errtrace"
 	"go.abhg.dev/doc2go/internal/errdefer"
 )
 
 func readFile(name string) (_ []byte, err error) {
 	f, err := os.Open(name)
 	if err != nil {
-		return nil, err
+		return nil, errtrace.Wrap(err)
 	}
 	defer errdefer.Close(&err, f)
 	// NOTE: err must be a named return.
 
-	return io.ReadAll(f)
+	return errtrace.Wrap2(io.ReadAll(f))
 }
 
 // This is a contrived example

--- a/internal/flagvalue/file_switch.go
+++ b/internal/flagvalue/file_switch.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"io"
 	"os"
+
+	"braces.dev/errtrace"
 )
 
 // FileSwitch is a flag that accepts both "-x" and "-x=value",
@@ -60,7 +62,7 @@ func (fs *FileSwitch) Create(fallback io.Writer) (w io.Writer, done func() error
 	default:
 		f, err := os.Create(string(*fs))
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, errtrace.Wrap(err)
 		}
 		return f, f.Close, nil
 	}

--- a/internal/flagvalue/list.go
+++ b/internal/flagvalue/list.go
@@ -3,6 +3,8 @@ package flagvalue
 import (
 	"fmt"
 	"strings"
+
+	"braces.dev/errtrace"
 )
 
 // List is a generic flag.Getter
@@ -38,7 +40,7 @@ func (lv *List[T, PT]) String() string {
 func (lv *List[T, PT]) Set(s string) error {
 	var v T
 	if err := PT(&v).Set(s); err != nil {
-		return err
+		return errtrace.Wrap(err)
 	}
 	*lv = append(*lv, v)
 	return nil

--- a/internal/flagvalue/list_test.go
+++ b/internal/flagvalue/list_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"testing"
 
+	"braces.dev/errtrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -90,7 +91,7 @@ func (sv *fallibleStringValue) String() string { return string(*sv) }
 
 func (sv *fallibleStringValue) Set(s string) error {
 	if s == "fail" {
-		return errors.New("great sadness")
+		return errtrace.Wrap(errors.New("great sadness"))
 	}
 	*sv = fallibleStringValue(s)
 	return nil

--- a/internal/godoc/assemble.go
+++ b/internal/godoc/assemble.go
@@ -182,7 +182,7 @@ func (as *assembly) importFor(name, imp string) *highlight.Code {
 	if err != nil {
 		// If the syntax highlighter fails,
 		// show the statement without highlighting.
-		as.logf("Error highlighting import statement: %v", err)
+		as.logf("Error highlighting import statement: %+v", err)
 		return &highlight.Code{
 			Spans: []highlight.Span{
 				&highlight.TextSpan{Text: buff.Bytes()},
@@ -379,7 +379,7 @@ func (as *assembly) eg(parent ExampleParent, dex *doc.Example) (ex *Example) {
 
 	code, err := as.egCode(dex)
 	if err != nil {
-		as.logf("Could not format example defined in %v: %v", as.fset.Position(dex.Code.Pos()), err)
+		as.logf("Could not format example defined in %v: %+v", as.fset.Position(dex.Code.Pos()), err)
 		code = &highlight.Code{
 			Spans: []highlight.Span{
 				&highlight.ErrorSpan{

--- a/internal/godoc/assemble.go
+++ b/internal/godoc/assemble.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"slices"
 
+	"braces.dev/errtrace"
 	"go.abhg.dev/doc2go/internal/gosrc"
 	"go.abhg.dev/doc2go/internal/highlight"
 	"go.abhg.dev/doc2go/internal/sliceutil"
@@ -67,7 +68,7 @@ func (a *Assembler) Assemble(bpkg *gosrc.Package) (*Package, error) {
 
 	dpkg, err := doc.NewFromFiles(bpkg.Fset, allSyntaxes, bpkg.ImportPath)
 	if err != nil {
-		return nil, fmt.Errorf("assemble documentation: %w", err)
+		return nil, errtrace.Wrap(fmt.Errorf("assemble documentation: %w", err))
 	}
 
 	newDeclFormatter := newDefaultDeclFormatter
@@ -412,13 +413,13 @@ func (as *assembly) egCode(dex *doc.Example) (*highlight.Code, error) {
 
 	var buff bytes.Buffer
 	if err := format.Node(&buff, as.fset, n); err != nil {
-		return nil, fmt.Errorf("format example: %w", err)
+		return nil, errtrace.Wrap(fmt.Errorf("format example: %w", err))
 	}
 	src := gosrc.FormatExample(buff.Bytes())
 
 	tokens, err := as.lexer.Lex(src)
 	if err != nil {
-		return nil, fmt.Errorf("highlight example: %w", err)
+		return nil, errtrace.Wrap(fmt.Errorf("highlight example: %w", err))
 	}
 
 	return &highlight.Code{

--- a/internal/godoc/assemble_test.go
+++ b/internal/godoc/assemble_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"braces.dev/errtrace"
 	"github.com/alecthomas/chroma/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -798,7 +799,7 @@ func newPlainDeclFormatter(pkg *gosrc.Package) DeclFormatter {
 func (f *plainDeclFormatter) FormatDecl(decl ast.Decl) ([]byte, []gosrc.Region, error) {
 	var buff bytes.Buffer
 	err := format.Node(&buff, f.fset, decl)
-	return buff.Bytes(), nil, err
+	return buff.Bytes(), nil, errtrace.Wrap(err)
 }
 
 type nopLexer struct{}
@@ -822,7 +823,7 @@ type stubLexer struct {
 var _ highlight.Lexer = (*stubLexer)(nil)
 
 func (l *stubLexer) Lex([]byte) ([]chroma.Token, error) {
-	return l.Result, l.Err
+	return l.Result, errtrace.Wrap(l.Err)
 }
 
 type srcPackage struct {

--- a/internal/godoc/synopsis.go
+++ b/internal/godoc/synopsis.go
@@ -169,7 +169,7 @@ func OneLineNodeDepth(fset *token.FileSet, node ast.Node, depth int) string {
 		// As a fallback, use default formatter for all unknown node types.
 		buf := new(bytes.Buffer)
 		err := format.Node(buf, fset, node)
-		must.NotErrorf(err, "Error formatting node: %v", err)
+		must.NotErrorf(err, "Error formatting node: %+v", err)
 		s := buf.String()
 		if strings.Contains(s, "\n") {
 			return dotDotDot

--- a/internal/gosrc/decl.go
+++ b/internal/gosrc/decl.go
@@ -9,6 +9,8 @@ import (
 	"go/scanner"
 	"go/token"
 	"strconv"
+
+	"braces.dev/errtrace"
 )
 
 // DeclFormatter formats declarations from a single Go package.
@@ -49,7 +51,7 @@ func (f *DeclFormatter) FormatDecl(decl ast.Decl) (src []byte, regions []Region,
 
 	var buff bytes.Buffer
 	if err := format.Node(&buff, f.fset, decl); err != nil {
-		return nil, nil, fmt.Errorf("format decl: %w", err)
+		return nil, nil, errtrace.Wrap(fmt.Errorf("format decl: %w", err))
 	}
 	src = buff.Bytes()
 

--- a/internal/gosrc/decl_test.go
+++ b/internal/gosrc/decl_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"braces.dev/errtrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -290,7 +291,7 @@ func TestDeclFormatter(t *testing.T) {
 
 				name, ok := tt.imports[path]
 				if !ok {
-					return nil, fmt.Errorf("unknown import %q", path)
+					return nil, errtrace.Wrap(fmt.Errorf("unknown import %q", path))
 				}
 
 				o := ast.NewObj(ast.Pkg, name)

--- a/internal/gosrc/ex_test.go
+++ b/internal/gosrc/ex_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"braces.dev/errtrace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -284,13 +285,13 @@ loop:
 		case token.RBRACE:
 			depth--
 			if depth < 0 {
-				return nil, fmt.Errorf("unmatched brace at %v", file.Offset(pos))
+				return nil, errtrace.Wrap(fmt.Errorf("unmatched brace at %v", file.Offset(pos)))
 			}
 			if depth == 0 {
 				// There shouldn't be any more tokens after this.
 				pos, tok, _ := scan.Scan()
 				if tok != token.EOF {
-					return nil, fmt.Errorf("unexpected token %v at %v", tok, file.Offset(pos))
+					return nil, errtrace.Wrap(fmt.Errorf("unexpected token %v at %v", tok, file.Offset(pos)))
 				}
 			}
 		case token.COMMENT, token.SEMICOLON:
@@ -301,7 +302,7 @@ loop:
 	}
 
 	if depth > 0 {
-		return nil, errors.New("file ended before closing brace")
+		return nil, errtrace.Wrap(errors.New("file ended before closing brace"))
 	}
 
 	return toks, nil

--- a/internal/gosrc/finder.go
+++ b/internal/gosrc/finder.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 
+	"braces.dev/errtrace"
 	"go.abhg.dev/doc2go/internal/sliceutil"
 	"golang.org/x/tools/go/packages"
 )
@@ -83,11 +84,11 @@ func (f *Finder) FindPackages(patterns ...string) ([]*PackageRef, error) {
 
 	pkgs, err := packages.Load(&cfg, patterns...)
 	if err != nil {
-		return nil, err
+		return nil, errtrace.Wrap(err)
 	}
 
 	if len(pkgs) == 0 {
-		return nil, errors.New("no packages found")
+		return nil, errtrace.Wrap(errors.New("no packages found"))
 	}
 
 	infos := make([]*PackageRef, 0, len(pkgs))

--- a/internal/gosrc/finder.go
+++ b/internal/gosrc/finder.go
@@ -101,7 +101,7 @@ func (f *Finder) FindPackages(patterns ...string) ([]*PackageRef, error) {
 		var pkgFailed bool
 		for _, err := range pkg.Errors {
 			pkgFailed = true
-			f.Log.Printf("[%v] %v", pkg.PkgPath, err)
+			f.Log.Printf("[%v] %+v", pkg.PkgPath, err)
 		}
 		if pkgFailed {
 			continue
@@ -120,7 +120,7 @@ func (f *Finder) FindPackages(patterns ...string) ([]*PackageRef, error) {
 		pkgDir := filepath.Dir(goFiles[0])
 		var testFiles []string
 		if ents, err := os.ReadDir(pkgDir); err != nil {
-			f.Log.Printf("[%v] Skipping tests: unable to read directory: %v", pkg.PkgPath, err)
+			f.Log.Printf("[%v] Skipping tests: unable to read directory: %+v", pkg.PkgPath, err)
 		} else {
 			// FIXME: This ignores build tags in test files.
 			// Maybe, it should be two load calls:

--- a/internal/gosrc/parser.go
+++ b/internal/gosrc/parser.go
@@ -6,6 +6,8 @@ import (
 	"go/parser"
 	"go/token"
 	"sort"
+
+	"braces.dev/errtrace"
 )
 
 // Package is a package that has been loaded from disk.
@@ -40,7 +42,7 @@ func (*Parser) ParsePackage(ref *PackageRef) (*Package, error) {
 	files := make(map[string]*ast.File)
 	syntax, err := parseFiles(fset, ref.Files, files)
 	if err != nil {
-		return nil, err
+		return nil, errtrace.Wrap(err)
 	}
 
 	var topLevel []string
@@ -54,7 +56,7 @@ func (*Parser) ParsePackage(ref *PackageRef) (*Package, error) {
 
 	testSyntax, err := parseFiles(fset, ref.TestFiles, nil /* fmap */)
 	if err != nil {
-		return nil, err
+		return nil, errtrace.Wrap(err)
 	}
 
 	return &Package{
@@ -81,7 +83,7 @@ func parseFiles(fset *token.FileSet, files []string, fmap map[string]*ast.File) 
 		var err error
 		syntax[i], err = parser.ParseFile(fset, file, nil, parser.ParseComments)
 		if err != nil {
-			return nil, fmt.Errorf("parse file %q: %w", file, err)
+			return nil, errtrace.Wrap(fmt.Errorf("parse file %q: %w", file, err))
 		}
 		if fmap != nil {
 			fmap[file] = syntax[i]
@@ -104,7 +106,7 @@ func packageRefImporter(ref *PackageRef) ast.Importer {
 
 		name, ok := packageNames[path]
 		if !ok {
-			return nil, fmt.Errorf("package %q not found", path)
+			return nil, errtrace.Wrap(fmt.Errorf("package %q not found", path))
 		}
 
 		pkg = ast.NewObj(ast.Pkg, name)

--- a/internal/highlight/highlight.go
+++ b/internal/highlight/highlight.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sync"
 
+	"braces.dev/errtrace"
 	chroma "github.com/alecthomas/chroma/v2"
 	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
 )
@@ -43,7 +44,7 @@ func (h *Highlighter) WriteCSS(w io.Writer) error {
 		return nil
 	}
 
-	return h.formatter.WriteCSS(w, h.Style)
+	return errtrace.Wrap(h.formatter.WriteCSS(w, h.Style))
 }
 
 // Highlight renders the given code block into HTML.

--- a/internal/highlight/lex.go
+++ b/internal/highlight/lex.go
@@ -1,6 +1,7 @@
 package highlight
 
 import (
+	"braces.dev/errtrace"
 	chroma "github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
 )
@@ -18,5 +19,5 @@ type chromaLexer struct{ l chroma.Lexer }
 
 // Lex lexically analyzes the given source code using Chroma.
 func (cl *chromaLexer) Lex(src []byte) ([]chroma.Token, error) {
-	return chroma.Tokenise(cl.l, nil, string(src))
+	return errtrace.Wrap2(chroma.Tokenise(cl.l, nil, string(src)))
 }

--- a/internal/html/render_test.go
+++ b/internal/html/render_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	ttemplate "text/template"
 
+	"braces.dev/errtrace"
 	"github.com/andybalholm/cascadia"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,7 +35,7 @@ func TestRenderer_WriteStatic(t *testing.T) {
 	var want []string
 	err = fs.WalkDir(_staticFS, "static", func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return errtrace.Wrap(err)
 		}
 		want = append(want, strings.TrimPrefix(path, "static"))
 		return nil
@@ -45,7 +46,7 @@ func TestRenderer_WriteStatic(t *testing.T) {
 	var got []string
 	err = fs.WalkDir(os.DirFS(dir), "_", func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return errtrace.Wrap(err)
 		}
 		got = append(got, strings.TrimPrefix(path, "_"))
 		return nil

--- a/internal/must/must.go
+++ b/internal/must/must.go
@@ -12,6 +12,6 @@ func panicf(format string, args ...interface{}) {
 // NotErrorf panics with the given message if the error is not nil.
 func NotErrorf(err error, format string, args ...interface{}) {
 	if err != nil {
-		panicf("unexpected error: %v\n%v", err, fmt.Sprintf(format, args...))
+		panicf("unexpected error: %+v\n%v", err, fmt.Sprintf(format, args...))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 
+	"braces.dev/errtrace"
 	"github.com/alecthomas/chroma/v2/styles"
 	"go.abhg.dev/doc2go/internal/godoc"
 	"go.abhg.dev/doc2go/internal/gosrc"
@@ -104,7 +105,7 @@ func (cmd *mainCmd) run(opts *params) error {
 		style := styles.Get(theme)
 		if style == nil {
 			if opts.HighlightPrintCSS {
-				return fmt.Errorf("unknown theme %q", theme)
+				return errtrace.Wrap(fmt.Errorf("unknown theme %q", theme))
 			}
 
 			cmd.log.Printf("Unknown theme %q. Falling back to %q.", theme, _defaultStyle.Name)
@@ -117,7 +118,7 @@ func (cmd *mainCmd) run(opts *params) error {
 	}
 
 	if opts.HighlightPrintCSS {
-		return highlighter.WriteCSS(cmd.Stdout)
+		return errtrace.Wrap(highlighter.WriteCSS(cmd.Stdout))
 	}
 
 	finder := gosrc.Finder{
@@ -131,7 +132,7 @@ func (cmd *mainCmd) run(opts *params) error {
 
 	pkgRefs, err := finder.FindPackages(opts.Patterns...)
 	if err != nil {
-		return fmt.Errorf("find packages: %w", err)
+		return errtrace.Wrap(fmt.Errorf("find packages: %w", err))
 	}
 
 	if home := opts.Home; home != "" {
@@ -152,7 +153,7 @@ func (cmd *mainCmd) run(opts *params) error {
 	for _, lt := range opts.PkgDocs {
 		t, err := template.New(lt.Path).Parse(lt.Template)
 		if err != nil {
-			return fmt.Errorf("bad package documentation template %q: %w", lt.String(), err)
+			return errtrace.Wrap(fmt.Errorf("bad package documentation template %q: %w", lt.String(), err))
 		}
 		linker.Template(lt.Path, t)
 	}
@@ -164,12 +165,12 @@ func (cmd *mainCmd) run(opts *params) error {
 	if path := opts.FrontMatter; len(path) > 0 {
 		bs, err := os.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("-frontmatter: %w", err)
+			return errtrace.Wrap(fmt.Errorf("-frontmatter: %w", err))
 		}
 
 		frontmatter, err = template.New(path).Parse(string(bs))
 		if err != nil {
-			return fmt.Errorf("bad frontmatter template: %w\n%s", err, bs)
+			return errtrace.Wrap(fmt.Errorf("bad frontmatter template: %w\n%s", err, bs))
 		}
 	}
 
@@ -197,5 +198,5 @@ func (cmd *mainCmd) run(opts *params) error {
 		DocLinker:  &linker,
 	}
 
-	return g.Generate(pkgRefs)
+	return errtrace.Wrap(g.Generate(pkgRefs))
 }

--- a/main.go
+++ b/main.go
@@ -60,18 +60,18 @@ func (cmd *mainCmd) Run(args []string) (exitCode int) {
 		if errors.Is(err, errHelp) {
 			return 0
 		}
-		fmt.Fprintln(cmd.Stderr, err)
+		fmt.Fprintf(cmd.Stderr, "%+v\n", err)
 		return 1
 	}
 
 	debugw, closedebug, err := opts.Debug.Create(cmd.Stderr)
 	if err != nil {
-		cmd.log.Printf("Unable to create debug log, using stderr: %v", err)
+		cmd.log.Printf("Unable to create debug log, using stderr: %+v", err)
 		debugw = cmd.Stderr
 	} else {
 		defer func() {
 			if err := closedebug(); err != nil {
-				cmd.log.Printf("Error closing debug log: %v", err)
+				cmd.log.Printf("Error closing debug log: %+v", err)
 			}
 		}()
 	}
@@ -79,7 +79,7 @@ func (cmd *mainCmd) Run(args []string) (exitCode int) {
 	cmd.debugLog = log.New(debugw, "", 0)
 
 	if err := cmd.run(opts); err != nil {
-		cmd.log.Printf("doc2go: %v", err)
+		cmd.log.Printf("doc2go: %+v", err)
 		return 1
 	}
 	return 0

--- a/main_test.go
+++ b/main_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"braces.dev/errtrace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.abhg.dev/doc2go/internal/iotest"
@@ -179,12 +180,12 @@ func testMainCmdGenerate(t *testing.T, exporter packagestest.Exporter) {
 			gotFiles := make(map[string]string)
 			err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 				if err != nil || d.IsDir() {
-					return err
+					return errtrace.Wrap(err)
 				}
 
 				got, err := fs.ReadFile(fsys, path)
 				if err != nil {
-					return err
+					return errtrace.Wrap(err)
 				}
 				gotFiles[filepath.ToSlash(path)] = string(got)
 				t.Logf("Found file %v", path)


### PR DESCRIPTION
Use braces.dev/errtrace to instrument all error return sites.
Error traces are reported at failure with %+v.
