### PR TITLE
goreleaser: brews.tap -> brews.repository

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,7 @@ aurs:
       email: mail@abhinavg.net
 
 brews:
-  - tap:
+  - repository:
       owner: abhinav
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
brews.tap has been deprecated in favor of brews.repository.
Update the goreleaser configuration per
https://goreleaser.com/deprecations/#brewstap.
