### PR TITLE
doc: Search from GH Workflow, add FAQ

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
           cache: 'yarn'
           cache-dependency-path: docs/yarn.lock
       - name: Install Node dependencies

--- a/docs/content/en/docs/faq.md
+++ b/docs/content/en/docs/faq.md
@@ -1,0 +1,34 @@
+---
+title: Frequently asked questions
+linkTitle: FAQ
+weight: 20
+---
+
+If your question isn't answered here,
+please [start a discussion](https://github.com/abhinav/doc2go/discussions)
+or [create an issue](https://github.com/abhinav/doc2go/issues/new).
+
+## Troubleshooting
+
+This section addresses common issues and their solutions.
+
+### My web host doesn't like "/foo" URLs. They want "/foo/" URLs.
+
+By default, doc2go generates relative links in the form:
+
+```html
+<a href="../path/to/dst">...</a>
+```
+
+If your web host prefers directories to have a trailing slash,
+run doc2go with `-rel-link-style=directory`.
+
+```sh
+doc2go -rel-link-style=directory ./...
+```
+
+This will generate:
+
+```html
+<a href="../path/to/dst/">...</a>
+```

--- a/docs/content/en/docs/publish/github-pages.md
+++ b/docs/content/en/docs/publish/github-pages.md
@@ -165,3 +165,52 @@ Now, the documentation for that package will be at:
 Use the import path for your module instead of the above
 if you're using a vanity import path.
 {{% /alert %}}
+
+## Adding search
+
+doc2go supports [client-side search]({{< relref "/docs/usage/search" >}})
+powered by [Pagefind](https://pagefind.app).
+
+To add search to your documentation, follow these steps:
+
+1. Install Pagefind to your repository with NPM.
+
+    ```bash
+    npm install pagefind@latest
+    ```
+
+    This will generate a package-lock.json,
+    locking the version of Pagefind in use.
+
+2. Check in the package.json and package-lock.json into your repository.
+
+    ```bash
+    git add package.json package-lock.json
+    git commit -m "Pin Pagefind version"
+    ```
+
+    In the future, you can use `npm update` to update to the latest version.
+
+3. In the GitHub Workflow, add steps to set up Node and download Pagefind
+   before the "Generate API reference" step.
+
+    ```yaml
+              - name: Set up Node
+                uses: actions/setup-node@v4
+                with:
+                  cache: 'npm'
+                  cache-dependency-path: package-lock.json
+                  # Specify a different cache-dependency-path if you didn't
+                  # run the command in the root of the repository.
+
+              - name: Install Pagefind
+                run: npm install
+    ```
+
+4. Modify the command in the "Generate API Reference" step
+   to pass the path to the newly installed Pagefind binary.
+
+    ```yaml
+              - name: Generate API reference
+                run: doc2go -pagefind=node_modules/.bin/pagefind ./...
+    ```

--- a/docs/content/en/docs/publish/github-pages.md
+++ b/docs/content/en/docs/publish/github-pages.md
@@ -203,7 +203,7 @@ To add search to your documentation, follow these steps:
                   # Specify a different cache-dependency-path if you didn't
                   # run the command in the root of the repository.
 
-              - name: Install Pagefind
+              - name: Install Node dependencies
                 run: npm install
     ```
 

--- a/docs/content/en/docs/usage/highlight.md
+++ b/docs/content/en/docs/usage/highlight.md
@@ -1,5 +1,5 @@
 ---
-title: Syntax Highlighting
+title: Syntax highlighting
 description: >-
   Customize doc2go's syntax highlighting of code blocks.
 weight: 3


### PR DESCRIPTION
In the GitHub Pages deployment instructions,
explain how to add client-side search to the site.

Also adds an FAQ section to the documentation
intended to address common questions and issues.
