### PR TITLE
html: Don't suffix static asset links with "/"

### DIFF
--- a/.changes/unreleased/Fixed-20240212-194229.yaml
+++ b/.changes/unreleased/Fixed-20240212-194229.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: '-rel-link-style: Don''t generate trailling ''/'' for static assets.'
+time: 2024-02-12T19:42:29.769904-08:00

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -167,8 +167,10 @@ func TestDirectoryRelativeLinks(t *testing.T) {
 
 	root := generate(t, "-rel-link-style=directory", "./...")
 	visitLocalURLs(t, root, &visitOptions{ShouldVisit: func(local localURL) bool {
-		if local.Kind != localPage {
-			return false
+		if local.Kind == localAsset {
+			return assert.False(t,
+				strings.HasSuffix(local.URL.Path, "/"),
+				"%v: path for relative asset ends with '/': %v", local.From, local.Href)
 		}
 
 		href := local.Href

--- a/internal/html/render.go
+++ b/internal/html/render.go
@@ -446,6 +446,13 @@ func (r *render) relativePath(p string) string {
 	return p
 }
 
+// Returns the relative path to a file, generally a static asset.
+//
+// No trailing '/' is added.
+func (r *render) relativePathFile(p string) string {
+	return relative.Path(r.Path, p)
+}
+
 // Returns the path to a static asset stored in the output directory.
 // If -subdir was used, these assets are shared with other websites.
 func (r *render) static(p string) string {
@@ -454,7 +461,7 @@ func (r *render) static(p string) string {
 		elem = append(elem, "..")
 	}
 	elem = append(elem, StaticDir, p)
-	return r.relativePath(path.Join(elem...))
+	return r.relativePathFile(path.Join(elem...))
 }
 
 // Returns the path to an asset stored in the site directory
@@ -463,7 +470,7 @@ func (r *render) static(p string) string {
 func (r *render) siteStatic(p string) string {
 	elem := []string{r.Home}
 	elem = append(elem, StaticDir, p)
-	return r.relativePath(path.Join(elem...))
+	return r.relativePathFile(path.Join(elem...))
 }
 
 func (r *render) code(code *highlight.Code) template.HTML {

--- a/internal/html/render_test.go
+++ b/internal/html/render_test.go
@@ -256,6 +256,15 @@ func TestRenderPackage_index(t *testing.T) {
 			}
 		}
 		assert.Equal(t, tt.want, items)
+
+		for _, link := range querySelectorAll(doc, "link") {
+			href := attr(link, "href")
+			if assert.NotEmpty(t, href) {
+				staticPath := "static/" + strings.TrimPrefix(href, "_/")
+				_, err := _staticFS.ReadFile(staticPath)
+				require.NoError(t, err)
+			}
+		}
 	}
 
 	for _, tt := range tests {
@@ -277,6 +286,18 @@ func TestRenderPackage_index(t *testing.T) {
 
 				runTest(t, (&Renderer{
 					Highlighter: _fakeHighlighter,
+				}), tt)
+			})
+
+			t.Run("Standalone with trailing slash", func(t *testing.T) {
+				t.Parallel()
+
+				ensureTrailingSlash := func(s string) string {
+					return strings.TrimSuffix(s, "/") + "/"
+				}
+				runTest(t, (&Renderer{
+					Highlighter:           _fakeHighlighter,
+					NormalizeRelativePath: ensureTrailingSlash,
 				}), tt)
 			})
 		})


### PR DESCRIPTION
When `-rel-link-style` is set to `directory`, the renderer is suffixing static asset links with `/` but these are file links that should not be suffixed.