### PR TITLE
docs: Add a godoc-tricks example

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,11 +4,13 @@ DOC2GO = $(shell pwd)/../bin/doc2go
 EMBEDDED_REF = content/en/api/_index.html
 STANDALONE_REF = content/en/example/index.html
 STD_REF = content/en/std/index.html
+TRICKS_REF = content/en/tricks/index.html
 
 DEPS = \
 	standalone \
 	embedded \
 	std \
+	tricks \
 	assets/scss/_chroma.scss \
 	content/en/docs/usage/config-keys.txt
 
@@ -24,7 +26,7 @@ serve: $(DEPS)
 
 .PHONY: clean
 clean:
-	rm -fr content/en/api/ content/en/example/ content/en/std/
+	rm -fr content/en/api/ content/en/example/ content/en/std/ content/en/tricks/
 	rm -fr public/*
 
 .PHONY: standalone
@@ -36,6 +38,9 @@ embedded: $(EMBEDDED_REF)
 .PHONY: std
 std: $(STD_REF)
 
+.PHONY: tricks
+tricks: $(TRICKS_REF)
+
 $(STD_REF): $(DOC2GO) $(PAGEFIND)
 	$(DOC2GO) -pagefind=$(PAGEFIND) -out=content/en/std std
 
@@ -44,6 +49,9 @@ $(STANDALONE_REF): $(DOC2GO) $(PAGEFIND)
 
 $(EMBEDDED_REF): $(DOC2GO) frontmatter.tmpl
 	cd .. && $(DOC2GO) -config docs/embed.rc ./...
+
+$(TRICKS_REF): $(DOC2GO) frontmatter.tmpl
+	cd .. && $(DOC2GO) -config docs/tricks.rc github.com/fluhus/godoc-tricks
 
 assets/scss/_chroma.scss: $(DOC2GO)
 	$(DOC2GO) -highlight=tango -highlight-print-css > $@

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -44,6 +44,9 @@ sidebar_menu_compact = false
   name = "doc2go (embedded)"
   url = "api/"
 [[params.menu.examples]]
+  name = "godoc tricks (embedded)"
+  url = "tricks/"
+[[params.menu.examples]]
   name = "doc2go (standalone)"
   url = "example/"
 [[params.menu.examples]]

--- a/docs/content/en/.gitignore
+++ b/docs/content/en/.gitignore
@@ -1,3 +1,4 @@
 /api
 /example
 /std
+/tricks

--- a/docs/doc.go
+++ b/docs/doc.go
@@ -1,0 +1,8 @@
+// Package docs generates documentation for doc2go.
+//
+// The Go package exists just to isolate the documentation
+// from the actual code,
+// and to add any dependencies needed for documentation generation.
+package docs
+
+import _ "github.com/fluhus/godoc-tricks"

--- a/docs/tricks.rc
+++ b/docs/tricks.rc
@@ -1,0 +1,11 @@
+embed
+internal
+home github.com/fluhus/godoc-tricks
+
+highlight classes:tango
+
+# Hugo-needs
+basename _index.html
+frontmatter docs/frontmatter.tmpl
+
+out docs/content/en/tricks

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	braces.dev/errtrace v0.3.0
 	github.com/alecthomas/chroma/v2 v2.12.0
 	github.com/andybalholm/cascadia v1.3.2
+	github.com/fluhus/godoc-tricks v1.5.0
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/net v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/fluhus/godoc-tricks v1.5.0 h1:Lp6HwVoqR1Seq/m9oFlB4naMsGF/s8mZkrc3fc0Bqtg=
+github.com/fluhus/godoc-tricks v1.5.0/go.mod h1:JmQHC4SZPrhHwG6nmGspQzs5f14X4spiabuH+WX4fMQ=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/peterbourgon/ff/v3 v3.4.0 h1:QBvM/rizZM1cB0p0lGMdmR7HxZeI/ZrBWB4DqLkMUBc=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,6 @@
+//go:build tools
+
+package main
+
+// For tricks page in documentation.
+import _ "github.com/fluhus/godoc-tricks"


### PR DESCRIPTION
Adds an example demonstrating the various features of godoc
with the godoc-tricks repository.

Thanks to @oliverpool for this sugggestion.

Resolves #197