### PR TITLE
Upgrade to latest Hugo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.121.2'
+          hugo-version: '0.123.4'
           extended: true
 
       - name: Build

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,3 +2,5 @@
 .hugo_build.lock
 /resources
 /node_modules
+/static/example
+/static/std

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,18 +1,18 @@
 SHELL = /bin/bash
 DOC2GO = $(shell pwd)/../bin/doc2go
 
-EMBEDDED_REF = content/en/api/_index.html
-STANDALONE_REF = content/en/example/index.html
-STD_REF = content/en/std/index.html
-TRICKS_REF = content/en/tricks/index.html
+DOC2GO_EMBED_ROOT = content/en/api/_index.html
+TRICKS_EMBED_ROOT = content/en/tricks/_index.html
+DOC2GO_STANDALONE_ROOT = static/example/index.html
+STD_STANDALONE_ROOT = static/std/index.html
 
 DEPS = \
-	standalone \
-	embedded \
-	std \
-	tricks \
-	assets/scss/_chroma.scss \
-	content/en/docs/usage/config-keys.txt
+       $(DOC2GO_STANDALONE_ROOT) \
+       $(DOC2GO_EMBED_ROOT) \
+       $(STD_STANDALONE_ROOT) \
+       $(TRICKS_EMBED_ROOT) \
+       assets/scss/_chroma.scss \
+       content/en/docs/usage/config-keys.txt
 
 PAGEFIND = $(shell pwd)/node_modules/.bin/pagefind
 
@@ -29,28 +29,16 @@ clean:
 	rm -fr content/en/api/ content/en/example/ content/en/std/ content/en/tricks/
 	rm -fr public/*
 
-.PHONY: standalone
-standalone: $(STANDALONE_REF)
+$(STD_STANDALONE_ROOT): $(DOC2GO) $(PAGEFIND)
+	$(DOC2GO) -pagefind=$(PAGEFIND) -out=static/std std
 
-.PHONY: embedded
-embedded: $(EMBEDDED_REF)
-
-.PHONY: std
-std: $(STD_REF)
-
-.PHONY: tricks
-tricks: $(TRICKS_REF)
-
-$(STD_REF): $(DOC2GO) $(PAGEFIND)
-	$(DOC2GO) -pagefind=$(PAGEFIND) -out=content/en/std std
-
-$(STANDALONE_REF): $(DOC2GO) $(PAGEFIND)
+$(DOC2GO_STANDALONE_ROOT): $(DOC2GO) $(PAGEFIND)
 	cd .. && $(DOC2GO) -config docs/standalone.rc -pagefind=$(PAGEFIND) ./...
 
-$(EMBEDDED_REF): $(DOC2GO) frontmatter.tmpl
+$(DOC2GO_EMBED_ROOT): $(DOC2GO) frontmatter.tmpl
 	cd .. && $(DOC2GO) -config docs/embed.rc ./...
 
-$(TRICKS_REF): $(DOC2GO) frontmatter.tmpl
+$(TRICKS_EMBED_ROOT): $(DOC2GO) frontmatter.tmpl
 	cd .. && $(DOC2GO) -config docs/tricks.rc github.com/fluhus/godoc-tricks
 
 assets/scss/_chroma.scss: $(DOC2GO)

--- a/docs/content/en/.gitignore
+++ b/docs/content/en/.gitignore
@@ -1,4 +1,2 @@
 /api
-/example
-/std
 /tricks

--- a/docs/standalone.rc
+++ b/docs/standalone.rc
@@ -1,3 +1,3 @@
 internal
 home go.abhg.dev/doc2go
-out docs/content/en/example
+out docs/static/example


### PR DESCRIPTION
The latest release of Hugo includes a change where
HTML pages inside contentDir are treated like regular pages.

This is fine for embedded pages, but for standalone pages we don't want
Hugo to attempt to post-process them.
Move standalone pages to static/ so they get published as-is.