### PR TITLE
highlight: fix index panic on certain inputs

### DIFF
--- a/.changes/unreleased/Fixed-20250827-215537.yaml
+++ b/.changes/unreleased/Fixed-20250827-215537.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix panic in highlighting certain corner cases.
+time: 2025-08-27T21:55:37.755691-07:00

--- a/internal/highlight/tokenindex.go
+++ b/internal/highlight/tokenindex.go
@@ -60,7 +60,9 @@ func (ts *TokenIndex) Interval(start, end int) (tokens []chroma.Token, lead, tra
 	// In that case, we'll drop that token but take text up to end
 	// as trailing text.
 	if off := ts.ends[endIdx]; end < off {
-		trail = ts.src[ts.starts[endIdx]:end]
+		if ts.starts[endIdx] < end {
+			trail = ts.src[ts.starts[endIdx]:end]
+		}
 	} else {
 		// If ends[endIdx] is equal to end, though,
 		// that token must be included in its entirety.


### PR DESCRIPTION
It's possible for TokenIndex.Interval to panic
if we're trying to capture trail text for a token
(because the end offset is in the middle of a token)
but the start of that token is at or after the requested end offset.
This will usually happen with chaotic whitespace.

The included unit test reproduces the panic without the fix.

Resolves #290